### PR TITLE
Add graph API, entity resolution service, and Superset OIDC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 KIND_CLUSTER := infoterminal
 K8S_CONTEXT := kind-$(KIND_CLUSTER)
 
-.PHONY: dev-up dev-down apps-up apps-down seed-demo print-info auth-up opa-up neo4j-up
+.PHONY: dev-up dev-down apps-up apps-down seed-demo seed-graph print-info auth-up opa-up neo4j-up
 
 auth-up:
 	@bash infra/scripts/keycloak-import.sh
@@ -33,6 +33,8 @@ dev-down:
 
 apps-up:
 	@uv run --python 3.11 -q --directory services/search-api ./dev.sh &
+	@uv run --python 3.11 -q --directory services/graph-api ./dev.sh &
+	@uv run --python 3.11 -q --directory services/entity-resolution ./dev.sh &
 	@pnpm --dir apps/frontend dev &
 
 apps-down:
@@ -41,6 +43,9 @@ apps-down:
 
 seed-demo:
 	@bash infra/scripts/seed-demo.sh
+
+seed-graph:
+	@python3 infra/scripts/seed-neo4j.py
 
 print-info:
 	@echo "Kubernetes context: $(K8S_CONTEXT)"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 ## Quickstart (Dev • Kind + Helm)
 ```bash
-make dev-up         # Kind-Cluster + Helm-Releases (PG, MinIO, OpenSearch, Keycloak, Traefik)
+make dev-up         # Kind-Cluster + Helm-Releases (PG, MinIO, OpenSearch, Keycloak, Traefik, Superset)
 make seed-demo      # Demo-Index + Demo-User anlegen
-make apps-up        # Startet Search-API (FastAPI) & Frontend (Next.js) lokal mit OIDC
+make auth-up        # Keycloak realm import
+make neo4j-up       # falls noch nicht durch dev-up angeworfen
+make seed-graph     # Demo-Graph in Neo4j
+
+make apps-up        # Startet Search-API, Graph-API, ER-Service & Frontend
 ```
 
 ## Start-Sequenz (kompakt)
@@ -13,7 +17,9 @@ make apps-up        # Startet Search-API (FastAPI) & Frontend (Next.js) lokal mi
 make dev-up         # Helm + OPA + Neo4j
 make seed-demo      # Demo-Index in OpenSearch
 make auth-up        # Keycloak realm import
-make apps-up        # Search-API + Frontend
+make neo4j-up       # (optional) Neo4j Manifeste
+make seed-graph     # Demo-Graph
+make apps-up        # Search-API + Graph-API + ER-Service + Frontend
 ```
 
 **Optional**: Auth wirklich erzwingen
@@ -31,6 +37,28 @@ uvicorn app:app --host 127.0.0.1 --port 8001 --reload
 * OpenSearch (Elasticsearch API) → [http://localhost:9200](http://localhost:9200)
 * PostgreSQL → localhost:5432
 * MinIO (S3) → [http://localhost:9000](http://localhost:9000)
+* Superset → [http://localhost:8088](http://localhost:8088)
+* Neo4j Browser → [http://localhost:7474](http://localhost:7474)
+
+**Services (Dev Endpoints)**
+
+```
+Frontend:        http://localhost:3000
+Search-API:      http://127.0.0.1:8001/healthz
+Graph-API:       http://127.0.0.1:8002/healthz
+ER-Service:      http://127.0.0.1:8003/docs
+Keycloak:        http://localhost:8081
+Superset:        http://localhost:8088
+Neo4j Browser:   http://localhost:7474
+```
+
+**Beispielaufrufe**
+
+```bash
+curl 'http://127.0.0.1:8002/neighbors?node_id=P:alice'
+curl -X POST 'http://127.0.0.1:8003/match' -H 'content-type: application/json' \
+  -d '{"query":"ACME Incorporated","candidates":["ACME Inc.","Globex","Acme, Inc."],"limit":3}'
+```
 
 **Ordner**
 

--- a/apps/frontend/pages/index.tsx
+++ b/apps/frontend/pages/index.tsx
@@ -33,6 +33,9 @@ export default function Home() {
             <b>{r.title}</b><br/>
             <small>{r.score?.toFixed?.(2)}</small>
             <div>{r.body}</div>
+            <div style={{marginTop:4}}>
+              <a href={`http://127.0.0.1:8002/neighbors?node_id=${encodeURIComponent(r.id || r.title)}`} target="_blank">Graph neighbors</a>
+            </div>
           </li>
         ))}
       </ul>

--- a/infra/helmfile/helmfile.yaml
+++ b/infra/helmfile/helmfile.yaml
@@ -70,8 +70,7 @@ releases:
     values:
       - service:
           type: NodePort
-          nodePorts:
-            http: 8088
+          nodePorts: { http: 8088 }
         supersetUsername: admin
         supersetPassword: adminadmin
         externalDatabase:
@@ -80,5 +79,36 @@ releases:
           password: app
           database: infoterminal
           port: 5432
-        ingress:
-          enabled: false
+        extraEnvVars:
+          - name: KC_ISSUER
+            value: "http://localhost:8081/realms/infoterminal"
+          - name: KC_CLIENT_ID
+            value: "superset"
+          - name: KC_CLIENT_SECRET
+            value: "superset-secret"
+        supersetExtraConfig: |
+          import os
+          from flask_appbuilder.security.manager import AUTH_OAUTH
+          AUTH_TYPE = AUTH_OAUTH
+          AUTH_USER_REGISTRATION = True
+          AUTH_USER_REGISTRATION_ROLE = "Gamma"
+          # DEV only – vermeidet CSRF-Probleme beim lokalen OIDC-Flow
+          WTF_CSRF_ENABLED = False
+
+          KC_ISSUER = os.getenv("KC_ISSUER", "").rstrip("/")
+          OAUTH_PROVIDERS = [
+            {
+              "name": "keycloak",
+              "icon": "fa-key",
+              "token_key": "access_token",
+              "remote_app": {
+                "client_id": os.getenv("KC_CLIENT_ID", "superset"),
+                "client_secret": os.getenv("KC_CLIENT_SECRET", "superset-secret"),
+                "access_token_url": f"{KC_ISSUER}/protocol/openid-connect/token",
+                "authorize_url": f"{KC_ISSUER}/protocol/openid-connect/auth",
+                "api_base_url": f"{KC_ISSUER}/protocol/openid-connect",
+                "userinfo_endpoint": f"{KC_ISSUER}/protocol/openid-connect/userinfo",
+                "client_kwargs": {"scope": "openid email profile"},
+              },
+            }
+          ]

--- a/infra/k8s/opa/opa.yaml
+++ b/infra/k8s/opa/opa.yaml
@@ -11,13 +11,12 @@ metadata:
 data:
   allow.rego: |
     package access
-
     default allow = false
 
-    allow {
-      input.user.roles[_] == "admin"
-    }
+    # admins dürfen alles
+    allow { input.user.roles[_] == "admin" }
 
+    # analysts: read auf public
     allow {
       input.user.roles[_] == "analyst"
       input.action == "read"

--- a/infra/keycloak/realm-infoterminal.json
+++ b/infra/keycloak/realm-infoterminal.json
@@ -32,6 +32,18 @@
       "webOrigins": ["*"],
       "standardFlowEnabled": false,
       "directAccessGrantsEnabled": true
+    },
+    {
+      "clientId": "superset",
+      "secret": "superset-secret",
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "serviceAccountsEnabled": false,
+      "redirectUris": ["http://localhost:8088/oauth-authorized/keycloak"],
+      "webOrigins": ["http://localhost:8088"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "attributes": { "pkce.code.challenge.method": "S256" }
     }
   ],
   "defaultRoles": ["analyst"],

--- a/infra/scripts/seed-neo4j.py
+++ b/infra/scripts/seed-neo4j.py
@@ -1,0 +1,16 @@
+from neo4j import GraphDatabase
+
+uri="bolt://localhost:7687"; user="neo4j"; pwd="neo4jpass"
+driver=GraphDatabase.driver(uri, auth=(user,pwd))
+with driver.session() as s:
+    s.run("MATCH (n) DETACH DELETE n")
+    s.run("""
+    MERGE (p1:Person {id:'P:alice', name:'Alice'})
+    MERGE (p2:Person {id:'P:bob', name:'Bob'})
+    MERGE (o1:Org {id:'O:acme', name:'ACME Inc.'})
+    MERGE (o2:Org {id:'O:globex', name:'Globex'})
+    MERGE (p1)-[:EMPLOYED_AT]->(o1)
+    MERGE (p2)-[:EMPLOYED_AT]->(o2)
+    MERGE (o1)-[:PARTNER_OF]->(o2)
+    """)
+print("Seeded.")

--- a/services/entity-resolution/app.py
+++ b/services/entity-resolution/app.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from rapidfuzz import process, fuzz
+from typing import List, Dict, Any
+
+app = FastAPI(title="Entity Resolution v0")
+
+class MatchReq(BaseModel):
+    query: str
+    candidates: List[str]
+    limit: int = 5
+    scorer: str = "token_sort_ratio"  # or "partial_ratio"
+
+SCORERS = {
+  "token_sort_ratio": fuzz.token_sort_ratio,
+  "partial_ratio": fuzz.partial_ratio,
+}
+
+@app.post("/match")
+def match(req: MatchReq):
+    scorer = SCORERS.get(req.scorer, fuzz.token_sort_ratio)
+    res = process.extract(req.query, req.candidates, scorer=scorer, limit=req.limit)
+    # res: List[(candidate, score, index)]
+    return [{"candidate": c, "score": float(s)} for c, s, _ in res]
+
+class DedupeReq(BaseModel):
+    items: List[str]
+    threshold: float = 90.0
+    scorer: str = "token_sort_ratio"
+
+@app.post("/dedupe")
+def dedupe(req: DedupeReq):
+    scorer = SCORERS.get(req.scorer, fuzz.token_sort_ratio)
+    clusters: List[List[str]] = []
+    visited = set()
+    for i, x in enumerate(req.items):
+        if i in visited: continue
+        group=[x]; visited.add(i)
+        for j, y in enumerate(req.items[i+1:], start=i+1):
+            if j in visited: continue
+            if scorer(x,y) >= req.threshold:
+                group.append(y); visited.add(j)
+        clusters.append(group)
+    return {"clusters": clusters}

--- a/services/entity-resolution/dev.sh
+++ b/services/entity-resolution/dev.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+uvicorn app:app --host 127.0.0.1 --port 8003 --reload

--- a/services/entity-resolution/pyproject.toml
+++ b/services/entity-resolution/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "entity-resolution"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["fastapi>=0.111", "uvicorn>=0.30", "rapidfuzz>=3.9"]
+
+[tool.uv]
+index-url = "https://pypi.org/simple"

--- a/services/graph-api/app.py
+++ b/services/graph-api/app.py
@@ -1,0 +1,71 @@
+import os
+from typing import Optional
+from fastapi import FastAPI, Depends, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from neo4j import GraphDatabase
+from auth import user_from_token
+from opa import allow
+
+NEO4J_URI = os.getenv("NEO4J_URI","bolt://localhost:7687")
+NEO4J_USER = os.getenv("NEO4J_USER","neo4j")
+NEO4J_PASS = os.getenv("NEO4J_PASS","neo4jpass")
+REQUIRE_AUTH = os.getenv("REQUIRE_AUTH","0") == "1"
+
+driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASS))
+
+app = FastAPI(title="InfoTerminal Graph API", version="0.1.0")
+app.add_middleware(
+  CORSMiddleware,
+  allow_origins=["http://localhost:3000","http://127.0.0.1:3000"],
+  allow_credentials=True, allow_methods=["*"], allow_headers=["*"]
+)
+
+def oidc_user(authorization: Optional[str] = Header(None)):
+    if not REQUIRE_AUTH: return {"sub":"dev","roles":["analyst"]}
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(401,"missing bearer token")
+    return user_from_token(authorization.split(" ",1)[1])
+
+@app.get("/healthz")
+def health():
+    with driver.session() as s:
+        s.run("RETURN 1").consume()
+    return {"status":"ok"}
+
+@app.get("/neighbors")
+def neighbors(node_id: str, limit: int = 20, user=Depends(oidc_user)):
+    if not allow(user,"read",{"classification":"public","type":"graph"}):
+        raise HTTPException(403,"forbidden")
+    q = """
+    MATCH (n {id: $id})-[r]-(m)
+    RETURN n, type(r) as rel, m
+    LIMIT $limit
+    """
+    with driver.session() as s:
+        recs = s.run(q, id=node_id, limit=limit)
+        out=[]
+        for r in recs:
+            out.append({
+              "from": dict(r["n"]),
+              "rel": r["rel"],
+              "to": dict(r["m"])
+            })
+        return out
+
+@app.get("/shortest_path")
+def shortest_path(src: str, dst: str, maxlen:int=6, user=Depends(oidc_user)):
+    if not allow(user,"read",{"classification":"public","type":"graph"}):
+        raise HTTPException(403,"forbidden")
+    q = """
+    MATCH (a {id:$src}), (b {id:$dst}),
+    p = shortestPath((a)-[*..$maxlen]-(b))
+    RETURN p
+    """
+    with driver.session() as s:
+        rec = s.run(q, src=src, dst=dst, maxlen=maxlen).single()
+        if not rec: return {"path":[]}
+        p = rec["p"]
+        return {
+          "nodes":[dict(n) for n in p.nodes],
+          "rels":[{"type": r.type, "start": p.nodes[p.relationships.index(r)].get("id"), "end": p.nodes[p.relationships.index(r)+1].get("id")} for r in p.relationships]
+        }

--- a/services/graph-api/auth.py
+++ b/services/graph-api/auth.py
@@ -1,0 +1,17 @@
+import os, httpx
+from jose import jwt
+from cachetools import TTLCache
+
+ISSUER = os.getenv("KEYCLOAK_ISSUER","http://localhost:8081/realms/infoterminal")
+AUDIENCE = os.getenv("KEYCLOAK_AUDIENCE","search-api")  # reuse audience; adjust if you create dedicated client
+JWKS_URL = f"{ISSUER}/protocol/openid-connect/certs"
+_cache = TTLCache(1, 300)
+
+def _jwks():
+    if "jwks" in _cache: return _cache["jwks"]
+    d = httpx.get(JWKS_URL, timeout=5).json(); _cache["jwks"]=d; return d
+
+def user_from_token(token:str):
+    claims = jwt.decode(token, _jwks(), algorithms=["RS256"], audience=AUDIENCE, issuer=ISSUER)
+    roles = claims.get("roles") or claims.get("realm_access",{}).get("roles",[])
+    return {"sub":claims.get("sub"), "roles":roles, "username":claims.get("preferred_username")}

--- a/services/graph-api/dev.sh
+++ b/services/graph-api/dev.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+export NEO4J_URI=${NEO4J_URI:-bolt://localhost:7687}
+export NEO4J_USER=${NEO4J_USER:-neo4j}
+export NEO4J_PASS=${NEO4J_PASS:-neo4jpass}
+uvicorn app:app --host 127.0.0.1 --port 8002 --reload

--- a/services/graph-api/opa.py
+++ b/services/graph-api/opa.py
@@ -1,0 +1,9 @@
+import os, httpx
+OPA_URL = os.getenv("OPA_URL","http://localhost:8181/v1/data/access/allow")
+def allow(user:dict, action:str, resource:dict)->bool:
+    try:
+        r = httpx.post(OPA_URL, json={"input":{"user":user,"action":action,"resource":resource}}, timeout=3)
+        r.raise_for_status()
+        return bool(r.json().get("result", False))
+    except Exception:
+        return True  # dev fail-open

--- a/services/graph-api/pyproject.toml
+++ b/services/graph-api/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "graph-api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.111", "uvicorn>=0.30", "neo4j>=5.23",
+  "python-jose[cryptography]>=3.3", "httpx>=0.27", "cachetools>=5.3"
+]
+
+[tool.uv]
+index-url = "https://pypi.org/simple"


### PR DESCRIPTION
## Summary
- configure Superset to use Keycloak via OIDC and add Superset client
- add graph-api service for Neo4j queries with OPA authorization
- add entity-resolution service using RapidFuzz and seed script for demo graph

## Testing
- `uv run --python 3.11 -q --directory services/graph-api python -m py_compile auth.py opa.py app.py`
- `uv run --python 3.11 -q --directory services/entity-resolution python -m py_compile app.py`
- `python3 -m py_compile infra/scripts/seed-neo4j.py`
- `pnpm --dir apps/frontend install` *(fails: ERR_PNPM_NO_MATCHING_VERSION No matching version found for next-auth@^5.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b745cf46ac83249c8ec11b60b090db