### PR TITLE
Integrate oauth2-proxy and OPA for edge authentication

### DIFF
--- a/infra/k8s/analytics/superset-ingress.yaml
+++ b/infra/k8s/analytics/superset-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: superset-edge
+  namespace: analytics
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: ingress-authz@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: superset.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: superset, port: { number: 8088 } } }

--- a/infra/k8s/analytics/superset-preset-job.yaml
+++ b/infra/k8s/analytics/superset-preset-job.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: superset-preset
+  namespace: analytics
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: seed
+        image: python:3.11-slim
+        command: ["/bin/sh","-c"]
+        args:
+          - pip install -q requests &&
+            python /work/seed.py
+        volumeMounts:
+          - { name: work, mountPath: /work }
+        env:
+          - { name: SUPERSET_URL, value: "http://superset.analytics.svc.cluster.local:8088" }
+          - { name: SUPERSET_USER, value: "admin" }
+          - { name: SUPERSET_PASS, value: "adminadmin" }
+          - { name: PG_HOST, value: "postgres-postgresql.data.svc.cluster.local" }
+          - { name: PG_PORT, value: "5432" }
+          - { name: PG_DB,   value: "infoterminal" }
+          - { name: PG_USER, value: "app" }
+          - { name: PG_PASS, value: "app" }
+      volumes:
+        - name: work
+          configMap:
+            name: superset-preset-scripts
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: superset-preset-scripts
+  namespace: analytics
+data:
+  seed.py: |
+    import os, time, requests, json
+    U=os.getenv("SUPERSET_URL")
+    s=requests.Session()
+    # 1) Login
+    r=s.post(f"{U}/api/v1/security/login", json={
+      "username": os.getenv("SUPERSET_USER"),
+      "password": os.getenv("SUPERSET_PASS"),
+      "provider": "db"
+    }); r.raise_for_status()
+    access=r.json()["access_token"]
+    s.headers.update({"Authorization": f"Bearer {access}"})
+    # 2) Database
+    conn=f"postgresql+psycopg2://{os.getenv('PG_USER')}:{os.getenv('PG_PASS')}@{os.getenv('PG_HOST')}:{os.getenv('PG_PORT')}/{os.getenv('PG_DB')}"
+    db_payload={"database_name":"infoterminal_pg","sqlalchemy_uri":conn,"expose_in_sqllab":True}
+    r=s.post(f"{U}/api/v1/database/", json=db_payload); 
+    if r.status_code not in (200,201): print("DB create:",r.text)
+    # get db id
+    dbs=s.get(f"{U}/api/v1/database/") .json()
+    db_id=[d["id"] for d in dbs["result"] if d["database_name"]=="infoterminal_pg"][0]
+    # 3) Dataset
+    ds_payload = {
+      "database": db_id,
+      "schema": "public",
+      "table_name": "stg_openbb_prices",
+      "extras": {}
+    }
+    r=s.post(f"{U}/api/v1/dataset/", json=ds_payload)
+    if r.status_code not in (200,201):
+        # falls bereits vorhanden, suche id
+        dss = s.get(f"{U}/api/v1/dataset/?q="+requests.utils.quote(json.dumps({"filters":[{"col":"table_name","opr":"eq","value":"stg_openbb_prices"}]}))).json()
+        ds_id = dss["result"][0]["id"]
+    else:
+        ds_id = r.json()["id"]
+    # 4) Chart (Time-series Line)
+    chart_payload = {
+      "slice_name": "OpenBB Close Price",
+      "viz_type": "echarts_timeseries_line",
+      "params": json.dumps({
+        "time_range": "No filter",
+        "metrics": ["sum__close"],
+        "groupby": ["symbol"],
+        "adhoc_filters": [],
+        "granularity_sqla": "as_of_date",
+        "x_axis": "as_of_date"
+      }),
+      "datasource_id": ds_id, "datasource_type": "table"
+    }
+    r=s.post(f"{U}/api/v1/chart/", json=chart_payload); 
+    if r.status_code not in (200,201): print("Chart:", r.text)
+    chart_id = (r.json().get("id") if r.status_code in (200,201) else s.get(f"{U}/api/v1/chart/").json()["result"][0]["id"])
+    # 5) Dashboard
+    dash_payload = {"dashboard_title":"OpenBB Overview","json_metadata":"{}","position_json":"{}","published":True,"duplicate_slices":False,"css":"", "slug":"openbb-overview"}
+    r=s.post(f"{U}/api/v1/dashboard/", json=dash_payload)
+    if r.status_code not in (200,201): print("Dashboard:", r.text)
+    dash = s.get(f"{U}/api/v1/dashboard/?q="+requests.utils.quote(json.dumps({"filters":[{"col":"dashboard_title","opr":"eq","value":"OpenBB Overview"}]}))).json()
+    dash_id = dash["result"][0]["id"]
+    # 6) Append chart to dashboard (simple superset pos json)
+    layout = {
+      "DASHBOARD_VERSION_KEY": "v2",
+      "ROOT_ID": {"type": "ROOT", "id": "ROOT_ID", "children": ["GRID_ID"]},
+      "GRID_ID": {"type": "GRID", "id": "GRID_ID", "children": ["ROW_ID"]},
+      "ROW_ID": {"type": "ROW", "id": "ROW_ID", "children": ["CHART_ID"], "meta": {"0":"CHART_ID"}},
+      "CHART_ID": {"type": "CHART", "id": "CHART_ID", "children": [], "meta": {"chartId": chart_id}}
+    }
+    s.put(f"{U}/api/v1/dashboard/{dash_id}", json={"position_json": json.dumps(layout)})
+    print("Superset preset done: Dashboard 'OpenBB Overview'")

--- a/infra/k8s/edge-auth/oauth2-proxy.yaml
+++ b/infra/k8s/edge-auth/oauth2-proxy.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Namespace
+metadata: { name: edge-auth }
+---
+apiVersion: v1
+kind: Secret
+metadata: { name: oauth2-proxy-secret, namespace: edge-auth }
+type: Opaque
+stringData:
+  client-id: edge-proxy
+  client-secret: edge-proxy-secret
+  cookie-secret: "replace_with_32byte_random_base64"  # z.B. `openssl rand -base64 32`
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: oauth2-proxy, namespace: edge-auth }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: oauth2-proxy } }
+  template:
+    metadata: { labels: { app: oauth2-proxy } }
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+        args:
+          - --provider=keycloak-oidc
+          - --oidc-issuer-url=http://localhost:8081/realms/infoterminal
+          - --client-id=$(CLIENT_ID)
+          - --client-secret=$(CLIENT_SECRET)
+          - --cookie-secret=$(COOKIE_SECRET)
+          - --cookie-secure=false
+          - --email-domain=*
+          - --reverse-proxy=true
+          - --http-address=0.0.0.0:4180
+          - --upstream=file:///dev/null
+          - --skip-provider-button=true
+          - --set-authorization-header=true
+          - --pass-authorization-header=true
+          - --pass-user-headers=true
+          - --pass-access-token=true
+        env:
+          - { name: CLIENT_ID, valueFrom: { secretKeyRef: { name: oauth2-proxy-secret, key: client-id } } }
+          - { name: CLIENT_SECRET, valueFrom: { secretKeyRef: { name: oauth2-proxy-secret, key: client-secret } } }
+          - { name: COOKIE_SECRET, valueFrom: { secretKeyRef: { name: oauth2-proxy-secret, key: cookie-secret } } }
+        ports: [{ containerPort: 4180 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: oauth2-proxy, namespace: edge-auth }
+spec:
+  selector: { app: oauth2-proxy }
+  ports: [{ name: http, port: 80, targetPort: 4180 }]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: edge-auth
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: auth.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: oauth2-proxy, port: { number: 80 } } }

--- a/infra/k8s/opa/authz-proxy.yaml
+++ b/infra/k8s/opa/authz-proxy.yaml
@@ -5,62 +5,56 @@ metadata:
   namespace: policy
 data:
   app.py: |
-    import os, json
+    import os
     from fastapi import FastAPI, Request, Response
     import httpx
-    from jose import jwt
     from cachetools import TTLCache
+    from jose import jwt
 
-    ISSUER = os.getenv("KEYCLOAK_ISSUER","http://localhost:8081/realms/infoterminal")
-    AUD = os.getenv("KEYCLOAK_AUDIENCE","search-api")
-    JWKS_URL = f"{ISSUER}/protocol/openid-connect/certs"
+    OAUTH2_AUTH = os.getenv("OAUTH2_AUTH","http://oauth2-proxy.edge-auth.svc.cluster.local/oauth2/auth")
     OPA_URL = os.getenv("OPA_URL","http://opa.policy.svc.cluster.local:8181/v1/data/access/allow")
+    ISSUER = os.getenv("KEYCLOAK_ISSUER","http://localhost:8081/realms/infoterminal")
     _cache = TTLCache(1, 300)
-
-    def _jwks():
-        if "jwks" in _cache: return _cache["jwks"]
-        d = httpx.get(JWKS_URL, timeout=5).json(); _cache["jwks"]=d; return d
-
-    def _user_from_authz(hv:str|None):
-        if not hv or not hv.startswith("Bearer "): return None
-        token = hv.split(" ",1)[1]
-        claims = jwt.decode(token, _jwks(), algorithms=["RS256"], audience=AUD, issuer=ISSUER)
-        roles = claims.get("roles") or claims.get("realm_access",{}).get("roles",[])
-        return {"sub":claims.get("sub"), "roles":roles, "username":claims.get("preferred_username")}
 
     app = FastAPI()
 
-    @app.get("/health") 
+    @app.get("/health")
     def health(): return {"ok": True}
 
     @app.get("/authz")
     async def authz(request: Request):
-        # allow unauthenticated pass-through (App kann OIDC selbst machen)
-        auth = request.headers.get("authorization")
-        user = None
-        if auth:
-            try:
-                user = _user_from_authz(auth)
-            except Exception:
-                # kein valider Token -> 401
-                return Response(status_code=401)
-
-        # Beispiel-Resource: aus Host/Path grob ableiten
-        host = request.headers.get("x-forwarded-host","")
-        resource = {"classification":"public","host":host}
-        inp = {"input":{"user": user or {"roles":["anonymous"]}, "action":"read", "resource": resource}}
+        # 1) AuthN via oauth2-proxy (Cookie Session)
+        headers = {k:v for k,v in request.headers.items() if k.lower().startswith("cookie") or k.lower().startswith("x-forwarded")}
         try:
-            r = httpx.post(OPA_URL, json=inp, timeout=3); r.raise_for_status()
-            allow = bool(r.json().get("result", False))
+            r = httpx.get(OAUTH2_AUTH, headers=headers, timeout=3.0)
+            if r.status_code != 202:
+                # nicht eingeloggt -> 401, Traefik leitet auf /oauth2/start um
+                return Response(status_code=401)
+            # Nutzerinfos aus oauth2-proxy Headers
+            user = {
+              "username": r.headers.get("X-Auth-Request-User") or r.headers.get("X-Forwarded-User") or "unknown",
+              "email": r.headers.get("X-Auth-Request-Email") or "",
+              "roles": (r.headers.get("X-Auth-Request-Groups") or "").split(",") if r.headers.get("X-Auth-Request-Groups") else ["analyst"]
+            }
         except Exception:
-            allow = True  # dev fail-open
+            # dev fail-open auf authn
+            user = {"username":"dev","roles":["analyst"]}
+
+        # 2) OPA-Decision (AuthZ)
+        host = request.headers.get("x-forwarded-host","")
+        path = request.headers.get("x-forwarded-uri","/")
+        resource = {"classification":"public","host":host,"path":path}
+        payload = {"input": {"user": user, "action":"read", "resource": resource}}
+        allow = True
+        try:
+            rr = httpx.post(OPA_URL, json=payload, timeout=3.0)
+            rr.raise_for_status()
+            allow = bool(rr.json().get("result", False))
+        except Exception:
+            allow = True  # dev
 
         if allow:
-            headers = {}
-            if user:
-                headers["X-User"] = user.get("username") or user.get("sub","")
-                headers["X-Roles"] = ",".join(user.get("roles",[]))
-            return Response(status_code=200, headers=headers)
+            return Response(status_code=200, headers={"X-User":user["username"], "X-Roles":",".join(user["roles"])})
         return Response(status_code=403)
 ---
 apiVersion: apps/v1

--- a/infra/k8s/openbb/cronjob.yaml
+++ b/infra/k8s/openbb/cronjob.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata: { name: openbb }
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openbb-prices-daily
+  namespace: openbb
+spec:
+  schedule: "5 4 * * 1-5"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: connector
+            image: openbb-connector:local
+            imagePullPolicy: IfNotPresent
+            env:
+              - { name: PG_HOST, value: "postgres-postgresql.data.svc.cluster.local" }
+              - { name: PG_PORT, value: "5432" }
+              - { name: PG_DB,   value: "infoterminal" }
+              - { name: PG_USER, value: "app" }
+              - { name: PG_PASS, value: "app" }
+              - { name: OPENBB_SYMBOLS, value: "AAPL,MSFT,SAP.DE,NVDA" }

--- a/infra/keycloak/realm-infoterminal.json
+++ b/infra/keycloak/realm-infoterminal.json
@@ -44,6 +44,17 @@
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
       "attributes": { "pkce.code.challenge.method": "S256" }
+    },
+    {
+      "clientId": "edge-proxy",
+      "secret": "edge-proxy-secret",
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "redirectUris": ["http://auth.127.0.0.1.nip.io/oauth2/callback"],
+      "webOrigins": ["http://auth.127.0.0.1.nip.io"],
+      "standardFlowEnabled": true,
+      "serviceAccountsEnabled": false,
+      "attributes": { "pkce.code.challenge.method": "S256" }
     }
   ],
   "defaultRoles": ["analyst"],

--- a/services/openbb-connector/Dockerfile
+++ b/services/openbb-connector/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml /app/
+RUN pip install -q --no-cache-dir uv && \
+    uv pip install --system pandas requests psycopg2-binary yfinance python-dotenv
+COPY main.py /app/
+CMD ["python","/app/main.py"]


### PR DESCRIPTION
## Summary
- add edge-proxy client to Keycloak realm
- deploy oauth2-proxy for edge OIDC and update authz-proxy to chain oauth2-proxy with OPA
- expose Superset via authenticated Ingress and seed initial dashboard data
- add OpenBB connector container and schedule CronJob

## Testing
- `make auth-up` *(fails: curl: (7) connection refused)*
- `kubectl version --client` *(fails: command not found)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74930a6948324bb324f351c87ad7f