### PR TITLE
Add Aleph and NiFi infrastructure, OPA tests, and Airflow KPO DAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 KIND_CLUSTER := infoterminal
 K8S_CONTEXT := kind-$(KIND_CLUSTER)
 
-.PHONY: dev-up dev-down apps-up apps-down seed-demo seed-graph print-info auth-up opa-up neo4j-up
+.PHONY: dev-up dev-down apps-up apps-down seed-demo seed-graph print-info auth-up opa-up neo4j-up opa-test
 
 auth-up:
 	@bash infra/scripts/keycloak-import.sh
@@ -50,3 +50,8 @@ seed-graph:
 print-info:
 	@echo "Kubernetes context: $(K8S_CONTEXT)"
 	@kubectl --context $(K8S_CONTEXT) get pods -A
+
+
+
+opa-test:
+	@docker run --rm -v $(PWD)/infra/k8s/opa:/pol -w /pol openpolicyagent/opa:0.64.0 test -v .

--- a/etl/airflow/dags/openbb_kpo.py
+++ b/etl/airflow/dags/openbb_kpo.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+
+with DAG(
+    dag_id="openbb_kpo_daily",
+    schedule="15 4 * * 1-5",
+    start_date=datetime(2025, 9, 1),
+    catchup=False,
+    default_args={"retries": 1, "retry_delay": timedelta(minutes=10)},
+    tags=["openbb","kpo"]
+) as dag:
+
+    run_connector = KubernetesPodOperator(
+        task_id="run_openbb_connector",
+        name="openbb-connector",
+        namespace="openbb",
+        image="openbb-connector:local",
+        image_pull_policy="IfNotPresent",
+        env_vars={
+            "PG_HOST": "postgres-postgresql.data.svc.cluster.local",
+            "PG_PORT": "5432",
+            "PG_DB": "infoterminal",
+            "PG_USER": "app",
+            "PG_PASS": "app",
+            "OPENBB_SYMBOLS": "AAPL,MSFT,SAP.DE,NVDA"
+        },
+        get_logs=True,
+        is_delete_operator_pod=True,
+    )

--- a/infra/k8s/aleph/aleph.yaml
+++ b/infra/k8s/aleph/aleph.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Namespace
+metadata: { name: docs }
+---
+apiVersion: v1
+kind: Secret
+metadata: { name: aleph-secret, namespace: docs }
+type: Opaque
+stringData:
+  ALEPH_SECRET_KEY: "change_me_supersecret"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: aleph-env, namespace: docs }
+data:
+  ALEPH_DATABASE_URI: "postgresql://app:app@postgres-postgresql.data.svc.cluster.local:5432/infoterminal"
+  ALEPH_ELASTICSEARCH_URI: "http://opensearch.search.svc.cluster.local:9200"
+  ALEPH_ARCHIVE_TYPE: "file"
+  ALEPH_ARCHIVE_PATH: "/data/archive"
+  ALEPH_URL: "http://aleph.127.0.0.1.nip.io"
+  ALEPH_DEBUG: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: aleph, namespace: docs }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: aleph } }
+  template:
+    metadata: { labels: { app: aleph } }
+    spec:
+      containers:
+      - name: web
+        image: alephdata/aleph:latest
+        envFrom:
+          - configMapRef: { name: aleph-env }
+          - secretRef: { name: aleph-secret }
+        ports: [ { containerPort: 8080 } ]
+        volumeMounts:
+          - { name: data, mountPath: /data }
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata: { name: aleph, namespace: docs }
+spec:
+  selector: { app: aleph }
+  ports: [ { name: http, port: 8080, targetPort: 8080 } ]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aleph
+  namespace: docs
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: ingress-authz@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: aleph.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: aleph, port: { number: 8080 } } }

--- a/infra/k8s/nifi/nifi.yaml
+++ b/infra/k8s/nifi/nifi.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata: { name: etl }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: nifi, namespace: etl }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: nifi } }
+  template:
+    metadata: { labels: { app: nifi } }
+    spec:
+      containers:
+      - name: nifi
+        image: apache/nifi:latest
+        env:
+          - { name: NIFI_WEB_HTTP_PORT, value: "8082" }
+        ports: [{ containerPort: 8082 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: nifi, namespace: etl }
+spec:
+  selector: { app: nifi }
+  ports: [{ name: http, port: 80, targetPort: 8082 }]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nifi
+  namespace: etl
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: nifi.127.0.0.1.nip.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: nifi, port: { number: 80 } } }

--- a/infra/k8s/opa/policies/allow.rego
+++ b/infra/k8s/opa/policies/allow.rego
@@ -1,0 +1,12 @@
+package access
+default allow = false
+
+# admins dürfen alles
+allow { input.user.roles[_] == "admin" }
+
+# analysts: read auf public
+allow {
+  input.user.roles[_] == "analyst"
+  input.action == "read"
+  input.resource.classification == "public"
+}

--- a/infra/k8s/opa/tests/allow_test.rego
+++ b/infra/k8s/opa/tests/allow_test.rego
@@ -1,0 +1,23 @@
+package access
+
+import data.access
+
+test_admin_can_read_anything {
+  input := {"user":{"roles":["admin"]},"action":"read","resource":{"classification":"secret"}}
+  access.allow with input as input
+}
+
+test_analyst_can_read_public {
+  input := {"user":{"roles":["analyst"]},"action":"read","resource":{"classification":"public"}}
+  access.allow with input as input
+}
+
+test_analyst_cannot_read_secret {
+  input := {"user":{"roles":["analyst"]},"action":"read","resource":{"classification":"secret"}}
+  not access.allow with input as input
+}
+
+test_anonymous_denied {
+  input := {"user":{"roles":["anonymous"]},"action":"read","resource":{"classification":"public"}}
+  not access.allow with input as input
+}

--- a/infra/nifi/scripts/upload-template.sh
+++ b/infra/nifi/scripts/upload-template.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+NIFI_URL=${NIFI_URL:-http://nifi.127.0.0.1.nip.io}
+TEMPLATE=infra/nifi/templates/openbb_prices_template.xml
+
+echo "→ Hole Root Process Group ID…"
+ROOT_ID=$(curl -s "$NIFI_URL/nifi-api/process-groups/root" | jq -r .id)
+
+echo "→ Lade Template hoch…"
+curl -s -X POST "$NIFI_URL/nifi-api/process-groups/$ROOT_ID/templates/upload" \
+  -H 'Content-Type: multipart/form-data' \
+  -F "template=@$TEMPLATE" >/dev/null
+
+echo "→ Liste Templates…"
+TID=$(curl -s "$NIFI_URL/nifi-api/flow/templates" | jq -r '.templates[-1].id')
+
+echo "→ Platziere Template…"
+curl -s -X POST "$NIFI_URL/nifi-api/process-groups/$ROOT_ID/template-instance" \
+  -H 'Content-Type: application/json' \
+  -d "{\"templateId\":\"$TID\",\"originX\":0.0,\"originY\":0.0}" >/dev/null
+
+echo "→ Starte alle Prozessoren…"
+PG=$(curl -s "$NIFI_URL/nifi-api/process-groups/$ROOT_ID/process-groups" | jq -r '.processGroups[0].id // empty')
+curl -s -X PUT "$NIFI_URL/nifi-api/flow/process-groups/$ROOT_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"'"$ROOT_ID"'","state":"RUNNING"}' >/dev/null || true
+echo "Fertig."

--- a/infra/nifi/templates/openbb_prices_template.xml
+++ b/infra/nifi/templates/openbb_prices_template.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<template encoding-version="1.3">
+  <name>OpenBB_Prices_Demo</name>
+  <description>InvokeHTTP → LogAttribute (Demo)</description>
+  <snippet>
+    <processGroups/>
+    <remoteProcessGroups/>
+    <processors>
+      <processor>
+        <id>00000000-0000-0000-0000-000000000001</id>
+        <name>GenerateFlowFile</name>
+        <class>org.apache.nifi.processors.standard.GenerateFlowFile</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>10 sec</schedulingPeriod>
+        <autoTerminatedRelationships>
+          <relationship>failure</relationship>
+        </autoTerminatedRelationships>
+        <properties>
+          <property>
+            <name>generate-ff-custom-text</name>
+            <value>{"symbols":"AAPL,MSFT,SAP.DE"}</value>
+          </property>
+          <property>
+            <name>File Size</name><value>0B</value>
+          </property>
+        </properties>
+      </processor>
+      <processor>
+        <id>00000000-0000-0000-0000-000000000002</id>
+        <name>InvokeHTTP (openbb-connector)</name>
+        <class>org.apache.nifi.processors.standard.InvokeHTTP</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>10 sec</schedulingPeriod>
+        <autoTerminatedRelationships>
+          <relationship>failure</relationship>
+        </autoTerminatedRelationships>
+        <properties>
+          <property>
+            <name>HTTP Method</name><value>POST</value>
+          </property>
+          <property>
+            <name>Remote URL</name><value>http://openbb-connector.openbb.svc.cluster.local/run</value>
+          </property>
+          <property>
+            <name>Content-Type</name><value>application/json</value>
+          </property>
+        </properties>
+      </processor>
+      <processor>
+        <id>00000000-0000-0000-0000-000000000003</id>
+        <name>LogAttribute</name>
+        <class>org.apache.nifi.processors.standard.LogAttribute</class>
+        <maxConcurrentTasks>1</maxConcurrentTasks>
+        <schedulingPeriod>10 sec</schedulingPeriod>
+      </processor>
+    </processors>
+    <connections>
+      <connection>
+        <id>c1</id>
+        <name>gen→invoke</name>
+        <sourceId>00000000-0000-0000-0000-000000000001</sourceId>
+        <sourceRelationship>success</sourceRelationship>
+        <destinationId>00000000-0000-0000-0000-000000000002</destinationId>
+      </connection>
+      <connection>
+        <id>c2</id>
+        <name>invoke→log</name>
+        <sourceId>00000000-0000-0000-0000-000000000002</sourceId>
+        <sourceRelationship>response</sourceRelationship>
+        <destinationId>00000000-0000-0000-0000-000000000003</destinationId>
+      </connection>
+    </connections>
+    <inputPorts/><outputPorts/><funnels/><labels/><controllerServices/>
+  </snippet>
+</template>


### PR DESCRIPTION
## Summary
- Add Aleph Kubernetes manifests for minimal docs deployment
- Provision Apache NiFi with template upload script for OpenBB demo
- Introduce OPA policy tests and Makefile target
- Schedule OpenBB connector via Airflow KubernetesPodOperator

## Testing
- `make opa-test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a51f8208324982b369bfa882a0a