### PR TITLE
Add doc-entities service and investigation assistant flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,13 @@ dev-down:
 	@kind delete cluster --name $(KIND_CLUSTER) || true
 
 apps-up:
-	@uv run --python 3.11 -q --directory services/search-api ./dev.sh &
-	@uv run --python 3.11 -q --directory services/graph-api ./dev.sh &
-	@uv run --python 3.11 -q --directory services/entity-resolution ./dev.sh &
-	@uv run --python 3.11 -q --directory services/graph-views ./dev.sh &
-	@pnpm --dir apps/frontend dev &
+       @uv run --python 3.11 -q --directory services/search-api ./dev.sh &
+       @uv run --python 3.11 -q --directory services/graph-api ./dev.sh &
+       @uv run --python 3.11 -q --directory services/entity-resolution ./dev.sh &
+       @uv run --python 3.11 -q --directory services/graph-views ./dev.sh &
+       @uv run --python 3.11 -q --directory services/nlp ./dev.sh &
+       @uv run --python 3.11 -q --directory services/doc-entities ./dev.sh &
+       @pnpm --dir apps/frontend dev &
 
 apps-down:
 	@pkill -f "uv run" || true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ make auth-up        # Keycloak realm import
 make neo4j-up       # falls noch nicht durch dev-up angeworfen
 make seed-graph     # Demo-Graph in Neo4j
 
-make apps-up        # Startet Search-API, Graph-API, ER-Service & Frontend
+make apps-up        # Startet Search-API, Graph-API, ER-Service, NLP, Doc-Entities & Frontend
 ```
 
 ## Start-Sequenz (kompakt)
@@ -19,7 +19,7 @@ make seed-demo      # Demo-Index in OpenSearch
 make auth-up        # Keycloak realm import
 make neo4j-up       # (optional) Neo4j Manifeste
 make seed-graph     # Demo-Graph
-make apps-up        # Search-API + Graph-API + ER-Service + Frontend
+make apps-up        # Search-API + Graph-API + ER-Service + NLP + Doc-Entities + Frontend
 ```
 
 **Optional**: Auth wirklich erzwingen
@@ -47,6 +47,8 @@ Frontend:        http://localhost:3000
 Search-API:      http://127.0.0.1:8001/healthz
 Graph-API:       http://127.0.0.1:8002/healthz
 ER-Service:      http://127.0.0.1:8003/docs
+NLP-Service:     http://127.0.0.1:8005/healthz
+Doc-Entities:    http://127.0.0.1:8006/healthz
 Keycloak:        http://localhost:8081
 Superset:        http://localhost:8088
 Neo4j Browser:   http://localhost:7474
@@ -86,3 +88,13 @@ cd apps/frontend && pnpm i && pnpm dev
 * Graph:    http://localhost:3000/graph
 * Airflow:  http://localhost:8084
 * OPA-Test: http://search.127.0.0.1.nip.io/search?q=info
+
+## n8n Flow: Investigation Assistant v1
+
+Die Datei `apps/n8n/investigation-assistant-v1.json` kann in n8n importiert und über den Webhook `/case` aufgerufen werden.
+
+Hinweise:
+
+* Auth: Falls die Airflow API Authentifizierung erfordert, entsprechende Header im HTTP-Node setzen.
+* Superset-Slug: auf den eigenen Dashboard-Slug anpassen (z. B. `openbb-overview`).
+* Symbol-Filter: Native-Filter-Parameter im Superset-Link ggf. anpassen.

--- a/apps/frontend/pages/docs/[id].tsx
+++ b/apps/frontend/pages/docs/[id].tsx
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+
+export default function DocPage(){
+  const { query } = useRouter()
+  const id = (query.id as string) || ""
+  const [html,setHtml] = useState<string>("")
+  useEffect(()=>{
+    if(!id) return
+    fetch(`http://127.0.0.1:8006/docs/${encodeURIComponent(id)}/html`)
+      .then(r=>r.text()).then(setHtml)
+  },[id])
+  return (
+    <main style={{maxWidth:920, margin:"24px auto"}}>
+      <div dangerouslySetInnerHTML={{__html: html}} />
+    </main>
+  )
+}

--- a/apps/n8n/investigation-assistant-v1.json
+++ b/apps/n8n/investigation-assistant-v1.json
@@ -1,0 +1,123 @@
+{
+  "name": "Investigation Assistant v1",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "case",
+        "options": { "responseCode": 200, "responseData": "allEntries" }
+      },
+      "id": "Webhook",
+      "name": "Webhook /case",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [ -200, 0 ]
+    },
+    {
+      "parameters": {
+        "url": "http://127.0.0.1:8001/search",
+        "options": {},
+        "queryParametersUi": {
+          "parameter": [
+            { "name": "q", "value": "={{$json.query || ('case:' + $json.caseId)}}" }
+          ]
+        }
+      },
+      "id": "SearchAPI",
+      "name": "Search API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [ 60, 0 ]
+    },
+    {
+      "parameters": { "options": {}, "functionCode": "const res = items[0].json;\nconst top = (res.results || []).slice(0,3);\nreturn top.map(r=>({json:r}));" },
+      "id": "Top3",
+      "name": "Top 3",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [ 300, 0 ]
+    },
+    {
+      "parameters": {
+        "url": "http://127.0.0.1:8006/annotate",
+        "options": { "bodyContentType": "json" },
+        "jsonParameters": true,
+        "sendBody": true,
+        "bodyParametersJson": "={\"doc_id\": $json.id || $json.title, \"title\": $json.title, \"text\": $json.body}"
+      },
+      "id": "Annotate",
+      "name": "Doc Annotate",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [ 540, -100 ]
+    },
+    {
+      "parameters": {
+        "url": "http://127.0.0.1:8005/summarize",
+        "options": { "bodyContentType": "json" },
+        "jsonParameters": true,
+        "sendBody": true,
+        "bodyParametersJson": "={\"text\": $json.body}"
+      },
+      "id": "Summarize",
+      "name": "Summarize",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [ 540, 100 ]
+    },
+    {
+      "parameters": {
+        "options": {},
+        "functionCode": "const caseId = $item(0).$node[\"Webhook /case\"].json.caseId;\nconst rows = [];\nfor (const i of $items(\"Top 3\", 0, $items().length)) {\n  const r = i.json;\n  const sum = i.$node[\"Summarize\"].json.summary || \"\";\n  const docUrl = `http://localhost:3000/docs/${encodeURIComponent(r.id||r.title)}`;\n  rows.push(`- **${r.title}** ([doc](${docUrl}))\\n  ${sum}`);\n}\nconst md = [\n  `# Case ${caseId}`,\n  `## Findings (Top 3)`,\n  rows.join("\\n"),\n].join("\\n\\n");\nreturn [{json: {markdown: md}}];"
+      },
+      "id": "ComposeNote",
+      "name": "Compose Note",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [ 800, 0 ]
+    },
+    {
+      "parameters": {
+        "url": "http://localhost:8084/api/v1/dags/openbb_kpo_daily/dagRuns",
+        "options": { "bodyContentType": "json" },
+        "jsonParameters": true,
+        "sendBody": true,
+        "bodyParametersJson": "={\"dag_run_id\": \"case-\" + $json.caseId + \"-\" + Date.now()}"
+      },
+      "id": "Airflow",
+      "name": "Trigger Airflow",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4,
+      "position": [ -20, 220 ]
+    },
+    {
+      "parameters": {
+        "options": {},
+        "functionCode": "const dash = 'openbb-overview'; // falls Slug anders: anpassen\nconst symbol = 'SAP.DE'; // simple Beispiel, sonst aus Ergebnissen ableiten\nconst supersetUrl = `http://superset.127.0.0.1.nip.io/superset/dashboard/${dash}/?native_filters_key=%7B%7D#`; \nreturn [{json: {superset: supersetUrl}}];"
+      },
+      "id": "SupersetLink",
+      "name": "Superset Link",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [ 1080, 0 ]
+    },
+    {
+      "parameters": {
+        "options": {},
+        "functionCode": "const md = $item(0).$node[\"Compose Note\"].json.markdown;\nconst sup = $item(0).$node[\"Superset Link\"].json.superset;\nreturn [{json: { markdown: md + \"\\n\\n**Analytics:** \" + sup }}];"
+      },
+      "id": "Assemble",
+      "name": "Assemble Response",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [ 1320, 0 ]
+    }
+  ],
+  "connections": {
+    "Webhook /case": { "main": [[ { "node": "Search API", "type": "main", "index": 0 }, { "node": "Trigger Airflow", "type": "main", "index": 0 } ]] },
+    "Search API": { "main": [[ { "node": "Top 3", "type": "main", "index": 0 } ]] },
+    "Top 3": { "main": [[ { "node": "Doc Annotate", "type": "main", "index": 0 }, { "node": "Summarize", "type": "main", "index": 0 } ]] },
+    "Compose Note": { "main": [[ { "node": "Superset Link", "type": "main", "index": 0 } ]] },
+    "Superset Link": { "main": [[ { "node": "Assemble Response", "type": "main", "index": 0 } ]] }
+  }
+}

--- a/services/doc-entities/app.py
+++ b/services/doc-entities/app.py
@@ -1,0 +1,123 @@
+import os, json, html
+from typing import Optional, List, Dict, Any
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import psycopg2, httpx
+
+PG = dict(
+  host=os.getenv("PG_HOST","localhost"),
+  port=int(os.getenv("PG_PORT","5432")),
+  dbname=os.getenv("PG_DB","infoterminal"),
+  user=os.getenv("PG_USER","app"),
+  password=os.getenv("PG_PASS","app"),
+)
+NLP_URL = os.getenv("NLP_URL","http://127.0.0.1:8005")
+GRAPH_URL = os.getenv("GRAPH_UI","http://localhost:3000/graphx")  # UI link
+
+def conn(): return psycopg2.connect(**PG)
+
+def init():
+  with conn() as c, c.cursor() as cur:
+    cur.execute("""
+      CREATE TABLE IF NOT EXISTS doc_texts (
+        doc_id text primary key,
+        title text,
+        text  text,
+        meta  jsonb,
+        created_at timestamptz default now(),
+        updated_at timestamptz default now()
+      );
+      CREATE TABLE IF NOT EXISTS doc_entities (
+        doc_id text references doc_texts(doc_id) on delete cascade,
+        ents   jsonb not null,
+        links  jsonb not null,
+        created_at timestamptz default now(),
+        primary key (doc_id)
+      );
+    """)
+init()
+
+app = FastAPI(title="Doc Entities", version="0.1.0")
+
+class AnnotReq(BaseModel):
+  doc_id: str
+  title: Optional[str] = None
+  text: str
+  meta: Optional[Dict[str, Any]] = None
+
+@app.get("/healthz")
+def health(): return {"ok": True}
+
+@app.post("/annotate")
+def annotate(req: AnnotReq):
+  # store text
+  with conn() as c, c.cursor() as cur:
+    cur.execute("""
+      INSERT INTO doc_texts (doc_id, title, text, meta)
+      VALUES (%s,%s,%s,%s)
+      ON CONFLICT (doc_id) DO UPDATE SET title=EXCLUDED.title, text=EXCLUDED.text, meta=EXCLUDED.meta, updated_at=now()
+    """, (req.doc_id, req.title, req.text, json.dumps(req.meta or {})))
+  # NER
+  with httpx.Client(timeout=30.0) as cli:
+    ner = cli.post(f"{NLP_URL}/ner", json={"text": req.text}).json()
+    links = cli.post(f"{NLP_URL}/resolve", json={"text": req.text, "ents": ner.get("ents", [])}).json()
+  ents = ner.get("ents", [])
+  lks  = links.get("links", [])
+  with conn() as c, c.cursor() as cur:
+    cur.execute("""
+      INSERT INTO doc_entities (doc_id, ents, links) VALUES (%s,%s,%s)
+      ON CONFLICT (doc_id) DO UPDATE SET ents=EXCLUDED.ents, links=EXCLUDED.links, created_at=now()
+    """, (req.doc_id, json.dumps(ents), json.dumps(lks)))
+  return {"doc_id": req.doc_id, "ents": ents, "links": lks}
+
+@app.get("/docs/{doc_id}")
+def get_doc(doc_id: str):
+  with conn() as c, c.cursor() as cur:
+    cur.execute("SELECT title,text,meta FROM doc_texts WHERE doc_id=%s", (doc_id,))
+    row = cur.fetchone()
+    if not row: raise HTTPException(404, "not found")
+    title, text, meta = row
+    cur.execute("SELECT ents,links FROM doc_entities WHERE doc_id=%s", (doc_id,))
+    er = cur.fetchone()
+  ents, links = (er or ([ ] ,[ ]) )
+  return {"doc_id": doc_id, "title": title, "text": text, "meta": meta, "ents": ents, "links": links}
+
+def _decorate(text: str, links: List[Dict[str,Any]]):
+  # markiere nur gelinkte Entitäten (mit node_id)
+  spans = []
+  for lk in links:
+    if "text" in lk and "node_id" in lk:
+      spans.append((lk.get("start"), lk.get("end"), lk["text"], lk["node_id"]))
+  # falls start/end fehlen, simple global replace (low-fi)
+  if not spans:
+    out = html.escape(text)
+    for lk in links:
+      t = html.escape(lk.get("text",""))
+      nid = lk.get("node_id","")
+      if not t or not nid: continue
+      out = out.replace(
+        t, f'<a class="ent" href="{GRAPH_URL}?focus={html.escape(nid)}" title="open in graph">{t}</a>'
+      )
+    return out
+  # mit Offsets (robuster)
+  spans = sorted([s for s in spans if s[0] is not None and s[1] is not None], key=lambda x: x[0])
+  out, cur = [], 0
+  for s,e,txt,nid in spans:
+    s = max(0, s); e = min(len(text), e or s)
+    out.append(html.escape(text[cur:s]))
+    out.append(f'<a class="ent" href="{GRAPH_URL}?focus={html.escape(nid)}" title="open in graph">{html.escape(text[s:e])}</a>')
+    cur = e
+  out.append(html.escape(text[cur:]))
+  return "".join(out)
+
+@app.get("/docs/{doc_id}/html")
+def get_doc_html(doc_id: str):
+  d = get_doc(doc_id)
+  body = _decorate(d["text"], d.get("links", []))
+  title = html.escape(d.get("title") or d["doc_id"])
+  html_doc = f"""<!doctype html>
+  <html><head><meta charset="utf-8"><title>{title}</title>
+  <style> body{{font:14px ui-sans-serif; max-width:860px; margin:24px auto;}}
+  .ent{{background:#fffae6; padding:1px 3px; border-radius:3px; text-decoration:none; border-bottom:1px dotted #888;}}</style>
+  </head><body><h1>{title}</h1><div>{body}</div></body></html>"""
+  return html_doc

--- a/services/doc-entities/dev.sh
+++ b/services/doc-entities/dev.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+uvicorn app:app --host 127.0.0.1 --port 8006 --reload

--- a/services/doc-entities/pyproject.toml
+++ b/services/doc-entities/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "doc-entities"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["fastapi>=0.111","uvicorn>=0.30","psycopg2-binary>=2.9","pydantic>=2.7","httpx>=0.27"]


### PR DESCRIPTION
## Summary
- add Doc Entities FastAPI service for storing texts and entity links
- expose document viewer page and n8n flow for investigation automation
- wire new services into dev stack and document setup

## Testing
- `python -m py_compile services/doc-entities/app.py`
- `bash -n services/doc-entities/dev.sh`
- `npx --yes tsc --pretty false --noEmit apps/frontend/pages/docs/[id].tsx` *(fails: Cannot find module 'next/router')*


------
https://chatgpt.com/codex/tasks/task_e_68b7543e153c8324b937eac98b4c75f8