### PR TITLE
Add ClickHouse audit dashboards and Vault bootstrap job

### DIFF
--- a/infra/analytics/superset_opa_audit.py
+++ b/infra/analytics/superset_opa_audit.py
@@ -1,0 +1,75 @@
+import os, json, requests
+
+U = os.getenv("SUPERSET_URL","http://superset.analytics.svc.cluster.local:8088")
+USER = os.getenv("SUPERSET_USER","admin")
+PASS = os.getenv("SUPERSET_PASS","adminadmin")
+
+DB_NAME="clickhouse_logs"
+SQLA = os.getenv("CH_URI","clickhousedb+connect://default:@clickhouse.clickhouse.svc.cluster.local:8123/logs")
+
+s = requests.Session()
+def login():
+    r = s.post(f"{U}/api/v1/security/login", json={"username":USER,"password":PASS,"provider":"db"})
+    r.raise_for_status()
+    s.headers.update({"Authorization": f"Bearer {r.json()['access_token']}"})
+
+def ensure_db():
+    r=s.get(f"{U}/api/v1/database/?q=%7B%22page_size%22:1000%7D").json()
+    for d in r["result"]:
+        if d["database_name"]==DB_NAME: return d["id"]
+    r=s.post(f"{U}/api/v1/database/", json={"database_name":DB_NAME,"sqlalchemy_uri":SQLA,"expose_in_sqllab":True})
+    r.raise_for_status(); return r.json()["id"]
+
+def ensure_dataset(db_id, schema, table_name):
+    q={"filters":[{"col":"table_name","opr":"eq","value":table_name},{"col":"schema","opr":"eq","value":schema},{"col":"database","opr":"rel_o_m","value":db_id}]}
+    r=s.get(f"{U}/api/v1/dataset/?q={requests.utils.quote(json.dumps(q))}").json()
+    if r["count"]>0: return r["result"][0]["id"]
+    r=s.post(f"{U}/api/v1/dataset/", json={"database":db_id,"schema":schema,"table_name":table_name})
+    r.raise_for_status(); return r.json()["id"]
+
+def ensure_chart(ds_id, name, viz_type, params):
+    q={"filters":[{"col":"slice_name","opr":"eq","value":name}]}
+    r=s.get(f"{U}/api/v1/chart/?q={requests.utils.quote(json.dumps(q))}").json()
+    payload={"slice_name":name,"viz_type":viz_type,"params":json.dumps(params),"datasource_id":ds_id,"datasource_type":"table"}
+    if r["count"]>0:
+        cid=r["result"][0]["id"]; s.put(f"{U}/api/v1/chart/{cid}", json=payload); return cid
+    r=s.post(f"{U}/api/v1/chart/", json=payload); r.raise_for_status(); return r.json()["id"]
+
+def ensure_dashboard(title, chart_ids):
+    q={"filters":[{"col":"dashboard_title","opr":"eq","value":title}]}
+    r=s.get(f"{U}/api/v1/dashboard/?q={requests.utils.quote(json.dumps(q))}").json()
+    if r["count"]==0:
+        r=s.post(f"{U}/api/v1/dashboard/", json={"dashboard_title":title,"published":True})
+        r.raise_for_status()
+    dash=s.get(f"{U}/api/v1/dashboard/?q={requests.utils.quote(json.dumps(q))}").json()["result"][0]
+    dash_id=dash["id"]
+    layout={"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"type":"ROOT","id":"ROOT_ID","children":["GRID"]},"GRID":{"type":"GRID","id":"GRID","children":[]}}
+    for i,cid in enumerate(chart_ids):
+        cid_key=f"CHART_{i}"
+        layout["GRID"]["children"].append(cid_key)
+        layout[cid_key]={"type":"CHART","id":cid_key,"children":[],"meta":{"chartId":cid}}
+    s.put(f"{U}/api/v1/dashboard/{dash_id}", json={"position_json":json.dumps(layout)})
+    return dash_id
+
+def main():
+    login()
+    db_id = ensure_db()
+    ds_id = ensure_dataset(db_id, "logs", "opa_decisions")
+    charts=[]
+    charts.append(ensure_chart(ds_id,"OPA Decisions per Minute","echarts_timeseries_line",{
+        "metrics":["count"],"groupby":["__time_grain"],"adhoc_filters":[],"time_grain_sqla":"minute","time_range":"Last 2 hours","x_axis":"__time"
+    }))
+    charts.append(ensure_chart(ds_id,"Deny Rate %","big_number_total",{
+        "metric":"count","adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"subheader":"Denies / All","y_axis_format":",.2f"
+    }))
+    charts.append(ensure_chart(ds_id,"Top Policies (denies)","table",{
+        "all_columns":["path","allowed"],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"order_by_cols":["[\"count\", false]"],"row_limit":10
+    }))
+    charts.append(ensure_chart(ds_id,"Top Users (denies)","table",{
+        "all_columns":["user","allowed"],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"order_by_cols":["[\"count\", false]"],"row_limit":10
+    }))
+    ensure_dashboard("OPA Audit (ClickHouse)", charts)
+    print("OPA Audit dashboard created.")
+
+if __name__=="__main__":
+    main()

--- a/infra/helmfile/helmfile.yaml
+++ b/infra/helmfile/helmfile.yaml
@@ -70,6 +70,7 @@ releases:
     chart: bitnami/superset
     createNamespace: true
     values:
+      - values/superset-values.yaml
       - service:
           type: NodePort
           nodePorts: { http: 8088 }

--- a/infra/helmfile/values/superset-values.yaml
+++ b/infra/helmfile/values/superset-values.yaml
@@ -1,0 +1,3 @@
+supersetNode:
+  extraPipPackages:
+    - clickhouse-connect==0.7.19

--- a/infra/k8s/analytics/superset-opa-audit-job.yaml
+++ b/infra/k8s/analytics/superset-opa-audit-job.yaml
@@ -1,0 +1,105 @@
+apiVersion: batch/v1
+kind: Job
+metadata: { name: superset-opa-audit, namespace: analytics }
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: job
+          image: python:3.11-slim
+          command: ["/bin/sh","-c"]
+          args: ["pip install -q requests && python /work/superset_opa_audit.py"]
+          env:
+            - { name: SUPERSET_URL, value: "http://superset.analytics.svc.cluster.local:8088" }
+            - { name: SUPERSET_USER, value: "admin" }
+            - { name: SUPERSET_PASS, value: "adminadmin" }
+            - { name: CH_URI, value: "clickhousedb+connect://default:@clickhouse.clickhouse.svc.cluster.local:8123/logs" }
+          volumeMounts:
+            - { name: work, mountPath: /work }
+      volumes:
+        - name: work
+          configMap:
+            name: superset-opa-audit-script
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: superset-opa-audit-script, namespace: analytics }
+data:
+  superset_opa_audit.py: |
+    import os, json, requests
+    
+    U = os.getenv("SUPERSET_URL","http://superset.analytics.svc.cluster.local:8088")
+    USER = os.getenv("SUPERSET_USER","admin")
+    PASS = os.getenv("SUPERSET_PASS","adminadmin")
+    
+    DB_NAME="clickhouse_logs"
+    SQLA = os.getenv("CH_URI","clickhousedb+connect://default:@clickhouse.clickhouse.svc.cluster.local:8123/logs")
+    
+    s = requests.Session()
+    def login():
+        r = s.post(f"{U}/api/v1/security/login", json={"username":USER,"password":PASS,"provider":"db"})
+        r.raise_for_status()
+        s.headers.update({"Authorization": f"Bearer {r.json()['access_token']}"})
+    
+    def ensure_db():
+        r=s.get(f"{U}/api/v1/database/?q=%7B%22page_size%22:1000%7D").json()
+        for d in r["result"]:
+            if d["database_name"]==DB_NAME: return d["id"]
+        r=s.post(f"{U}/api/v1/database/", json={"database_name":DB_NAME,"sqlalchemy_uri":SQLA,"expose_in_sqllab":True})
+        r.raise_for_status(); return r.json()["id"]
+    
+    def ensure_dataset(db_id, schema, table_name):
+        q={"filters":[{"col":"table_name","opr":"eq","value":table_name},{"col":"schema","opr":"eq","value":schema},{"col":"database","opr":"rel_o_m","value":db_id}]}
+        r=s.get(f"{U}/api/v1/dataset/?q={requests.utils.quote(json.dumps(q))}").json()
+        if r["count"]>0: return r["result"][0]["id"]
+        r=s.post(f"{U}/api/v1/dataset/", json={"database":db_id,"schema":schema,"table_name":table_name})
+        r.raise_for_status(); return r.json()["id"]
+    
+    def ensure_chart(ds_id, name, viz_type, params):
+        q={"filters":[{"col":"slice_name","opr":"eq","value":name}]}
+        r=s.get(f"{U}/api/v1/chart/?q={requests.utils.quote(json.dumps(q))}").json()
+        payload={"slice_name":name,"viz_type":viz_type,"params":json.dumps(params),"datasource_id":ds_id,"datasource_type":"table"}
+        if r["count"]>0:
+            cid=r["result"][0]["id"]; s.put(f"{U}/api/v1/chart/{cid}", json=payload); return cid
+        r=s.post(f"{U}/api/v1/chart/", json=payload); r.raise_for_status(); return r.json()["id"]
+    
+    def ensure_dashboard(title, chart_ids):
+        q={"filters":[{"col":"dashboard_title","opr":"eq","value":title}]}
+        r=s.get(f"{U}/api/v1/dashboard/?q={requests.utils.quote(json.dumps(q))}").json()
+        if r["count"]==0:
+            r=s.post(f"{U}/api/v1/dashboard/", json={"dashboard_title":title,"published":True})
+            r.raise_for_status()
+        dash=s.get(f"{U}/api/v1/dashboard/?q={requests.utils.quote(json.dumps(q))}").json()["result"][0]
+        dash_id=dash["id"]
+        layout={"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"type":"ROOT","id":"ROOT_ID","children":["GRID"]},"GRID":{"type":"GRID","id":"GRID","children":[]}}
+        for i,cid in enumerate(chart_ids):
+            cid_key=f"CHART_{i}"
+            layout["GRID"]["children"].append(cid_key)
+            layout[cid_key]={"type":"CHART","id":cid_key,"children":[],"meta":{"chartId":cid}}
+        s.put(f"{U}/api/v1/dashboard/{dash_id}", json={"position_json":json.dumps(layout)})
+        return dash_id
+    
+    def main():
+        login()
+        db_id = ensure_db()
+        ds_id = ensure_dataset(db_id, "logs", "opa_decisions")
+        charts=[]
+        charts.append(ensure_chart(ds_id,"OPA Decisions per Minute","echarts_timeseries_line",{
+            "metrics":["count"],"groupby":["__time_grain"],"adhoc_filters":[],"time_grain_sqla":"minute","time_range":"Last 2 hours","x_axis":"__time"
+        }))
+        charts.append(ensure_chart(ds_id,"Deny Rate %","big_number_total",{
+            "metric":"count","adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"subheader":"Denies / All","y_axis_format":",.2f"
+        }))
+        charts.append(ensure_chart(ds_id,"Top Policies (denies)","table",{
+            "all_columns":["path","allowed"],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"order_by_cols":["[\"count\", false]"],"row_limit":10
+        }))
+        charts.append(ensure_chart(ds_id,"Top Users (denies)","table",{
+            "all_columns":["user","allowed"],"adhoc_filters":[{"expressionType":"SIMPLE","subject":"allowed","operator":"==","comparator":"0"}],"order_by_cols":["[\"count\", false]"],"row_limit":10
+        }))
+        ensure_dashboard("OPA Audit (ClickHouse)", charts)
+        print("OPA Audit dashboard created.")
+    
+    if __name__=="__main__":
+        main()
+

--- a/infra/k8s/observability/grafana-clickhouse.yaml
+++ b/infra/k8s/observability/grafana-clickhouse.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: grafana, namespace: observability }
+spec:
+  template:
+    spec:
+      containers:
+        - name: grafana
+          env:
+            - { name: GF_INSTALL_PLUGINS, value: "grafana-clickhouse-datasource" }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-ds-clickhouse, namespace: observability }
+data:
+  clickhouse-ds.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: ClickHouse
+        type: grafana-clickhouse-datasource
+        access: proxy
+        isDefault: false
+        jsonData:
+          defaultDatabase: logs
+          server: clickhouse.clickhouse.svc.cluster.local
+          port: 8123
+          username: default
+        secureJsonData:
+          # falls du Auth nutzt, hier password setzen
+          password: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: grafana, namespace: observability }
+spec:
+  template:
+    spec:
+      containers:
+        - name: grafana
+          volumeMounts:
+            - { name: ds2, mountPath: /etc/grafana/provisioning/datasources/clickhouse.yaml, subPath: clickhouse-ds.yaml }
+      volumes:
+        - name: ds2
+          configMap: { name: grafana-ds-clickhouse }

--- a/infra/k8s/observability/grafana-dashboard-opa-audit.yaml
+++ b/infra/k8s/observability/grafana-dashboard-opa-audit.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-opa-audit
+  namespace: observability
+  labels: { grafana_dashboard: "1" }
+data:
+  opa-audit.json: |
+    {
+      "id": null,
+      "uid": "opa-audit-ch",
+      "title": "OPA Audit — Decisions (ClickHouse)",
+      "tags": ["opa","audit","clickhouse"],
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "10s",
+      "templating": {
+        "list": [
+          {
+            "name": "tenant",
+            "type": "query",
+            "datasource": "ClickHouse",
+            "query": "SELECT DISTINCT tenant FROM logs.opa_decisions ORDER BY tenant",
+            "includeAll": true,
+            "multi": true,
+            "refresh": 1
+          },
+          {
+            "name": "path",
+            "type": "query",
+            "datasource": "ClickHouse",
+            "query": "SELECT DISTINCT path FROM logs.opa_decisions ORDER BY path",
+            "includeAll": true,
+            "multi": true,
+            "refresh": 1
+          }
+        ]
+      },
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Decisions / min",
+          "gridPos": {"x":0,"y":0,"w":6,"h":4},
+          "datasource": "ClickHouse",
+          "targets": [
+            {
+              "query": "SELECT toStartOfMinute(ts) AS t, count() AS c FROM logs.opa_decisions WHERE 1=1 AND (tenant IN (${tenant:csv}) OR '${tenant:csv}' = '') AND (path IN (${path:csv}) OR '${path:csv}' = '') AND ts > now() - INTERVAL 1 HOUR GROUP BY t ORDER BY t",
+              "format": 1
+            }
+          ],
+          "options": {"reduceOptions":{"calcs":["last"]}}
+        },
+        {
+          "type": "stat",
+          "title": "Deny-Rate (%)",
+          "gridPos": {"x":6,"y":0,"w":6,"h":4},
+          "datasource": "ClickHouse",
+          "targets": [
+            {
+              "query": "WITH a AS (SELECT count() c FROM logs.opa_decisions WHERE allowed=1), d AS (SELECT count() c FROM logs.opa_decisions WHERE allowed=0) SELECT 100.0 * d.c / nullIf(a.c + d.c,0) AS deny_pct",
+              "format": 1
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Allows vs Denies (per 1m)",
+          "gridPos": {"x":12,"y":0,"w":12,"h":8},
+          "datasource": "ClickHouse",
+          "targets": [
+            {
+              "query": "SELECT toStartOfMinute(ts) AS t, 'allow' AS kind, count() c FROM logs.opa_decisions WHERE allowed=1 AND ts > now()-INTERVAL 2 HOUR GROUP BY t UNION ALL SELECT toStartOfMinute(ts) AS t, 'deny' AS kind, count() c FROM logs.opa_decisions WHERE allowed=0 AND ts > now()-INTERVAL 2 HOUR GROUP BY t ORDER BY t",
+              "format": 1
+            }
+          ]
+        },
+        {
+          "type": "bargauge",
+          "title": "Top Policies (by denies)",
+          "gridPos": {"x":0,"y":8,"w":12,"h":8},
+          "datasource": "ClickHouse",
+          "targets": [
+            {
+              "query": "SELECT path, count() AS c FROM logs.opa_decisions WHERE allowed=0 GROUP BY path ORDER BY c DESC LIMIT 10",
+              "format": 1
+            }
+          ]
+        },
+        {
+          "type": "table",
+          "title": "Top Users (denies)",
+          "gridPos": {"x":12,"y":8,"w":12,"h":8},
+          "datasource": "ClickHouse",
+          "targets": [
+            {
+              "query": "SELECT user, sum(allowed=0) AS denies, sum(allowed=1) AS allows, round(100.0*denies/nullIf(denies+allows,0),1) AS deny_pct FROM logs.opa_decisions GROUP BY user ORDER BY denies DESC LIMIT 20",
+              "format": 1
+            }
+          ]
+        }
+      ]
+    }

--- a/infra/k8s/secrets/vault-bootstrap-job.yaml
+++ b/infra/k8s/secrets/vault-bootstrap-job.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata: { name: vault-bootstrap, namespace: external-secrets }
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: vb
+          image: hashicorp/vault:1.16
+          command: ["/bin/sh","-lc"]
+          args:
+            - |
+              set -e
+              export VAULT_ADDR="$(cat /env/VAULT_ADDR)"
+              export VAULT_TOKEN="$(cat /env/VAULT_TOKEN)"
+              write() { vault kv put "kv/$1" $2; }
+              # Example secrets
+              write edge-auth/oauth2-proxy "client-id=dev-oidc" "client-secret=$(openssl rand -hex 24)" "cookie-secret=$(openssl rand -base64 32)"
+              write analytics/superset "admin-password=$(openssl rand -hex 16)"
+              write docs/aleph "ALEPH_SECRET_KEY=$(openssl rand -hex 32)"
+              write pg/app "username=app" "password=$(openssl rand -hex 12)"
+              echo "Bootstrap done."
+          volumeMounts:
+            - { name: env, mountPath: /env }
+      volumes:
+        - name: env
+          secret: { secretName: vault-bootstrap }

--- a/infra/k8s/secrets/vault-bootstrap-token.yaml
+++ b/infra/k8s/secrets/vault-bootstrap-token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata: { name: vault-bootstrap, namespace: external-secrets }
+type: Opaque
+stringData:
+  VAULT_ADDR: "http://vault.vault.svc.cluster.local:8200"
+  VAULT_TOKEN: "REPLACE_ME_DEV_ROOT_OR_BOOTSTRAP"


### PR DESCRIPTION
## Summary
- provision Grafana ClickHouse datasource and OPA audit dashboard
- seed default secrets via Vault bootstrap token and job
- automate Superset ClickHouse dashboard creation and install clickhouse-connect driver

## Testing
- `python -m py_compile infra/analytics/superset_opa_audit.py`
- `make opa-test` *(fails: Makefile:35: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a5b23e083248a78cfcbbe7be108