### PR TITLE
Add SLO dashboard, Superset audit helper, and demo playbook

### DIFF
--- a/apps/frontend/lib/superset-audit.ts
+++ b/apps/frontend/lib/superset-audit.ts
@@ -1,0 +1,33 @@
+type NF = {
+  id?: string;
+  column: string;
+  datasetId: number;
+  values?: (string|number)[];
+};
+type AuditFilterArgs = {
+  base: string;                // http://superset.127.0.0.1.nip.io
+  slug: string;                // Dashboard slug, z.B. "opa-audit-clickhouse"
+  datasetId: number;           // logs.opa_decisions dataset id
+  tenants?: string[];
+  paths?: string[];
+  timeRange?: string;          // "Last 24 hours", "Last 7 days"
+};
+
+export function auditDashboardUrl(a: AuditFilterArgs) {
+  const filters: NF[] = [];
+  if (a.tenants?.length) filters.push({ column: "tenant", datasetId: a.datasetId, values: a.tenants });
+  if (a.paths?.length)   filters.push({ column: "path", datasetId: a.datasetId, values: a.paths });
+  const state: any = {
+    native_filters: filters.map((f, i) => ({
+      id: f.id || `nf-${i}`,
+      filterState: { value: f.values ?? null },
+      targets: [{ column: f.column, datasetId: f.datasetId }],
+      type: "select"
+    })),
+    time_range: a.timeRange || "Last 24 hours"
+  };
+  const frag = encodeURIComponent(JSON.stringify(state));
+  const u = new URL(`/superset/dashboard/${a.slug}/`, a.base);
+  u.searchParams.set("standalone","0");
+  return `${u.toString()}#${frag}`;
+}

--- a/infra/k8s/observability/grafana-dashboard-slo.json
+++ b/infra/k8s/observability/grafana-dashboard-slo.json
@@ -1,0 +1,98 @@
+{
+  "uid": "obs-slo",
+  "title": "InfoTerminal — SLOs",
+  "tags": ["infoterminal","slo"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "version": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(spanmetrics_calls_total, service_name)",
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "target_p95_ms",
+        "type": "textbox",
+        "label": "SLO p95 target (ms)",
+        "query": "300",
+        "current": { "text": "300", "value": "300" }
+      },
+      {
+        "name": "error_budget_pct",
+        "type": "textbox",
+        "label": "Error budget (%)",
+        "query": "2",
+        "current": { "text": "2", "value": "2" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Current p95 (ms)",
+      "gridPos": {"x":0,"y":0,"w":6,"h":4},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "1000*histogram_quantile(0.95, sum by (le) (rate(spanmetrics_latency_bucket{service_name=\"$service\"}[5m])))" }
+      ],
+      "options": { "reduceOptions": {"calcs":["lastNotNull"]} }
+    },
+    {
+      "type": "stat",
+      "title": "SLO Met? (p95 ≤ target)",
+      "gridPos": {"x":6,"y":0,"w":6,"h":4},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "bool( 1000*histogram_quantile(0.95, sum by (le) (rate(spanmetrics_latency_bucket{service_name=\"$service\"}[5m]))) <= $target_p95_ms )" }
+      ],
+      "fieldConfig": { "defaults": { "mappings":[{"type":"value","options":{"0":{"text":"NO"},"1":{"text":"YES"}}}]} }
+    },
+    {
+      "type": "timeseries",
+      "title": "p50/p95/p99 vs Target",
+      "gridPos": {"x":12,"y":0,"w":12,"h":8},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "1000*histogram_quantile(0.50, sum by (le) (rate(spanmetrics_latency_bucket{service_name=\"$service\"}[5m])))", "legendFormat": "p50" },
+        { "expr": "1000*histogram_quantile(0.95, sum by (le) (rate(spanmetrics_latency_bucket{service_name=\"$service\"}[5m])))", "legendFormat": "p95" },
+        { "expr": "1000*histogram_quantile(0.99, sum by (le) (rate(spanmetrics_latency_bucket{service_name=\"$service\"}[5m])))", "legendFormat": "p99" },
+        { "expr": "$target_p95_ms", "legendFormat": "target" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Error rate (5m) %",
+      "gridPos": {"x":0,"y":8,"w":6,"h":4},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "100*sum(rate(spanmetrics_calls_total{service_name=\"$service\",http_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(spanmetrics_calls_total{service_name=\"$service\"}[5m])), 1e-6)" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Error budget remaining (%) — 30d",
+      "gridPos": {"x":6,"y":8,"w":6,"h":4},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "100 - (100* sum_over_time( (sum(rate(spanmetrics_calls_total{service_name=\"$service\",http_status_code=~\"5..\"}[5m])) / clamp_min(sum(rate(spanmetrics_calls_total{service_name=\"$service\"}[5m])),1e-6)) [30d:5m]) / (30*24*60/5) )" }
+      ],
+      "fieldConfig": { "defaults": { "thresholds": {"mode":"absolute","steps":[{"color":"green","value":20},{"color":"red","value":0}]}} }
+    },
+    {
+      "type": "timeseries",
+      "title": "Multi-Window Burn-Rate (1h/6h)",
+      "gridPos": {"x":12,"y":8,"w":12,"h":8},
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "(sum(rate(spanmetrics_calls_total{service_name=\"$service\",http_status_code=~\"5..\"}[1h])) / clamp_min(sum(rate(spanmetrics_calls_total{service_name=\"$service\"}[1h])),1e-6)) / ($error_budget_pct/100)", "legendFormat":"BR_1h" },
+        { "expr": "(sum(rate(spanmetrics_calls_total{service_name=\"$service\",http_status_code=~\"5..\"}[6h])) / clamp_min(sum(rate(spanmetrics_calls_total{service_name=\"$service\"}[6h])),1e-6)) / ($error_budget_pct/100)", "legendFormat":"BR_6h" }
+      ]
+    }
+  ]
+}

--- a/infra/k8s/observability/playbook-cron.yaml
+++ b/infra/k8s/observability/playbook-cron.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata: { name: demo-playbook, namespace: observability }
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: play
+              image: python:3.11-slim
+              command: ["/bin/sh","-c"]
+              args:
+                - pip install -q requests && python /w/demo_playbook.py
+              env:
+                - { name: BASE, value: "http://search-api.data.svc.cluster.local" }
+                - { name: EDGE_SEARCH, value: "http://search.127.0.0.1.nip.io" }
+                - { name: ITERS, value: "100" }
+                - { name: DELAY, value: "1.0" }
+              volumeMounts:
+                - { name: w, mountPath: /w }
+          volumes:
+            - name: w
+              configMap:
+                name: demo-playbook-src
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: demo-playbook-src, namespace: observability }
+data:
+  demo_playbook.py: |
+    import os, time, random, string, json, requests
+    
+    BASE = os.getenv("BASE","http://127.0.0.1")
+    SEARCH = os.getenv("SEARCH", f"{BASE}:8001")
+    GRAPH  = os.getenv("GRAPH",  f"{BASE}:8002")
+    EDGE_SEARCH = os.getenv("EDGE_SEARCH","http://search.127.0.0.1.nip.io")
+    USERS = [
+      {"username":"alice","roles":["analyst"],"tenant":"A"},
+      {"username":"bob","roles":["investigator"],"tenant":"A"},
+      {"username":"carol","roles":["analyst"],"tenant":"B"},
+      {"username":"root","roles":["admin"],"tenant":"*"}
+    ]
+    
+    def call_search_direct(q, user):
+      payload = {"q": q}
+      headers = {"X-Demo-User": json.dumps(user)}  # falls du das im Gateway in OPA input mappen willst
+      return requests.get(f"{SEARCH}/search", params=payload, headers=headers, timeout=5)
+    
+    def call_search_edge(q):
+      # über Edge → OIDC/OPA; für Demo ggf. ohne Auth -> erwartet 401/302
+      return requests.get(f"{EDGE_SEARCH}/search", params={"q":q}, timeout=5, allow_redirects=False)
+    
+    def call_graph_neighbors(node_id, user):
+      headers = {"X-Demo-User": json.dumps(user)}
+      return requests.get(f"{GRAPH}/neighbors", params={"node_id":node_id,"limit":50}, headers=headers, timeout=5)
+    
+    def rnd_word(n=5):
+      import random, string
+      return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+    
+    def run_once():
+      # 1) erlaubt/beleidigt über OPA → Denies erzeugen
+      try:
+        r = call_search_edge("info")
+        print("edge search:", r.status_code)
+      except Exception as e:
+        print("edge error:", e)
+    
+      # 2) direkte API (mit X-Demo-User → OPA input mapper)
+      u = random.choice(USERS)
+      q = random.choice(["acme", "berlin", "sap", "investigation", rnd_word(6)])
+      rs = call_search_direct(q, u)
+      print("direct search", u["username"], q, rs.status_code)
+    
+      # 3) graph neighbors
+      node = random.choice(["P:alice","O:acme","A:SAP.DE"])
+      rg = call_graph_neighbors(node, u)
+      print("graph", u["username"], node, rg.status_code)
+    
+    def main():
+      iters = int(os.getenv("ITERS","60"))
+      delay = float(os.getenv("DELAY","1.5"))
+      for i in range(iters):
+        run_once()
+        time.sleep(delay)
+    
+    if __name__ == "__main__":
+      main()

--- a/tools/demo_playbook.py
+++ b/tools/demo_playbook.py
@@ -1,0 +1,58 @@
+import os, time, random, string, json, requests
+
+BASE = os.getenv("BASE","http://127.0.0.1")
+SEARCH = os.getenv("SEARCH", f"{BASE}:8001")
+GRAPH  = os.getenv("GRAPH",  f"{BASE}:8002")
+EDGE_SEARCH = os.getenv("EDGE_SEARCH","http://search.127.0.0.1.nip.io")
+USERS = [
+  {"username":"alice","roles":["analyst"],"tenant":"A"},
+  {"username":"bob","roles":["investigator"],"tenant":"A"},
+  {"username":"carol","roles":["analyst"],"tenant":"B"},
+  {"username":"root","roles":["admin"],"tenant":"*"}
+]
+
+def call_search_direct(q, user):
+  payload = {"q": q}
+  headers = {"X-Demo-User": json.dumps(user)}  # falls du das im Gateway in OPA input mappen willst
+  return requests.get(f"{SEARCH}/search", params=payload, headers=headers, timeout=5)
+
+def call_search_edge(q):
+  # über Edge → OIDC/OPA; für Demo ggf. ohne Auth -> erwartet 401/302
+  return requests.get(f"{EDGE_SEARCH}/search", params={"q":q}, timeout=5, allow_redirects=False)
+
+def call_graph_neighbors(node_id, user):
+  headers = {"X-Demo-User": json.dumps(user)}
+  return requests.get(f"{GRAPH}/neighbors", params={"node_id":node_id,"limit":50}, headers=headers, timeout=5)
+
+def rnd_word(n=5):
+  import random, string
+  return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
+
+def run_once():
+  # 1) erlaubt/beleidigt über OPA → Denies erzeugen
+  try:
+    r = call_search_edge("info")
+    print("edge search:", r.status_code)
+  except Exception as e:
+    print("edge error:", e)
+
+  # 2) direkte API (mit X-Demo-User → OPA input mapper)
+  u = random.choice(USERS)
+  q = random.choice(["acme", "berlin", "sap", "investigation", rnd_word(6)])
+  rs = call_search_direct(q, u)
+  print("direct search", u["username"], q, rs.status_code)
+
+  # 3) graph neighbors
+  node = random.choice(["P:alice","O:acme","A:SAP.DE"])
+  rg = call_graph_neighbors(node, u)
+  print("graph", u["username"], node, rg.status_code)
+
+def main():
+  iters = int(os.getenv("ITERS","60"))
+  delay = float(os.getenv("DELAY","1.5"))
+  for i in range(iters):
+    run_once()
+    time.sleep(delay)
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- add Grafana SLO dashboard for latency and error budget metrics
- include Superset audit URL builder for generating dashboard deep links
- add demo playbook script and optional CronJob for generating traffic

## Testing
- `npm --prefix apps/frontend test` (fails: Missing script "test")
- `python3 -m py_compile tools/demo_playbook.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75c372c1c8324af059c92ad0f92cf