### PR TITLE
feat: add grafana alerting and dbt data quality monitoring

### DIFF
--- a/etl/dbt/tools/dbt_prom_exporter.py
+++ b/etl/dbt/tools/dbt_prom_exporter.py
@@ -1,0 +1,36 @@
+import json, os, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT=int(os.getenv("PORT","9108"))
+DIR=os.getenv("DBT_DIR","etl/dbt/target")
+
+def load_metrics():
+    m=[]
+    try:
+        rr=json.load(open(f"{DIR}/run_results.json"))
+        failed=sum(1 for r in rr.get("results",[]) if r.get("status") not in ("success","skipped"))
+        total=len(rr.get("results",[]))
+        m.append(("dbt_tests_total", total))
+        m.append(("dbt_tests_failed", failed))
+    except: pass
+    try:
+        src=json.load(open(f"{DIR}/sources.json"))
+        for ts in src.get("sources",[]):
+            n=ts["unique_id"].replace(".","_")
+            stale=1 if ts.get("max_loaded_at_time_ago_in_s",0) > ts.get("freshness",{}).get("warn_after",{}).get("count", 86400) else 0
+            m.append((f"dbt_source_stale{{source=\"{n}\"}}", stale))
+    except: pass
+    return m
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path!="/metrics":
+            self.send_response(404); self.end_headers(); return
+        ms=load_metrics()
+        out="\n".join([f"# HELP {k} .\n# TYPE {k} gauge\n{k} {v}" for k,v in ms])+"\n"
+        self.send_response(200); self.send_header("Content-Type","text/plain"); self.end_headers()
+        self.wfile.write(out.encode())
+
+if __name__=="__main__":
+    HTTPServer(("0.0.0.0", PORT), H).serve_forever()
+

--- a/infra/k8s/analytics/dbt-quality-cron.yaml
+++ b/infra/k8s/analytics/dbt-quality-cron.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata: { name: dbt-quality, namespace: analytics }
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: dbt
+              image: ghcr.io/dbt-labs/dbt-core:1.7.10
+              command: ["/bin/sh","-lc"]
+              args:
+                - dbt deps --project-dir /w/etl/dbt &&
+                  dbt run --project-dir /w/etl/dbt --select state:modified+ &&
+                  dbt test --project-dir /w/etl/dbt &&
+                  dbt source freshness --project-dir /w/etl/dbt --output json > /w/etl/dbt/target/sources.json &&
+                  sleep 5
+              volumeMounts: [{ name: repo, mountPath: /w }]
+            - name: exporter
+              image: python:3.11-slim
+              command: ["/bin/sh","-c"]
+              args: ["pip install -q && python /w/etl/dbt/tools/dbt_prom_exporter.py"]
+              ports: [{ containerPort: 9108, name: metrics }]
+              volumeMounts: [{ name: repo, mountPath: /w }]
+          volumes: [{ name: repo, hostPath: { path: "/workspace" } }]
+

--- a/infra/k8s/observability/grafana-alerting.yaml
+++ b/infra/k8s/observability/grafana-alerting.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+  namespace: observability
+data:
+  contactpoints.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: slack-main
+        receivers:
+          - uid: slack
+            type: slack
+            settings:
+              url: https://hooks.slack.com/services/REPLACE/ME/WEBHOOK
+              username: grafana
+              icon_emoji: ":rotating_light:"
+  policies.yaml: |
+    apiVersion: 1
+    policies:
+      - orgId: 1
+        receiver: slack-main
+        group_by: ['alertname']
+        routes:
+          - receiver: slack-main
+            matchers:
+              - severity="critical"
+          - receiver: slack-main
+            matchers:
+              - severity="warning"
+

--- a/infra/k8s/observability/grafana-dashboard-opa-audit.yaml
+++ b/infra/k8s/observability/grafana-dashboard-opa-audit.yaml
@@ -84,6 +84,23 @@ data:
               "query": "SELECT path, count() AS c FROM logs.opa_decisions WHERE allowed=0 GROUP BY path ORDER BY c DESC LIMIT 10",
               "format": 1
             }
+          ],
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "superset_url",
+                "mode": "binary",
+                "expression": "\"http://superset.127.0.0.1.nip.io/superset/dashboard/opa-audit-clickhouse/?standalone=0#\" + encodeURIComponent(JSON.stringify({ native_filters: [ { id: \\\"nf-tenant\\\", filterState:{ value: [\\\"${tenant}\\\"] }, targets:[{column:\\\"tenant\\\",datasetId: 77}], type:\\\"select\\\" }, { id: \\\"nf-path\\\", filterState:{ value: [\\\"${__field.name}\\\"] }, targets:[{column:\\\"path\\\",datasetId: 77}], type:\\\"select\\\" } ], time_range: \\\"Last 2 hours\\\" }))"
+              }
+            }
+          ],
+          "links": [
+            {
+              "title": "Open in Superset (filtered)",
+              "url": "${__data.fields.superset_url}",
+              "targetBlank": true
+            }
           ]
         },
         {

--- a/infra/k8s/observability/prom-grafana.yaml
+++ b/infra/k8s/observability/prom-grafana.yaml
@@ -76,9 +76,13 @@ spec:
           ports: [{ containerPort: 3000 }]
           volumeMounts:
             - { name: ds, mountPath: /etc/grafana/provisioning/datasources }
+            - { name: alerts, mountPath: /etc/grafana/provisioning/alerting/contactpoints.yaml, subPath: contactpoints.yaml }
+            - { name: alerts, mountPath: /etc/grafana/provisioning/alerting/policies.yaml, subPath: policies.yaml }
       volumes:
         - name: ds
           configMap: { name: grafana-datasources }
+        - name: alerts
+          configMap: { name: grafana-alerting }
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/observability/prom-scrape-dbt.yaml
+++ b/infra/k8s/observability/prom-scrape-dbt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: prometheus-config, namespace: observability }
+data:
+  prometheus.yaml: |
+    global: { scrape_interval: 15s }
+    scrape_configs:
+      - job_name: 'otel-collector'
+        static_configs: [{ targets: ['otel-collector.observability.svc.cluster.local:8889'] }]
+      - job_name: 'dbt-quality'
+        static_configs: [{ targets: ['dbt-quality.analytics.svc.cluster.local:9108'] }]
+

--- a/infra/k8s/observability/rule-dbt-freshness.yaml
+++ b/infra/k8s/observability/rule-dbt-freshness.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-rule-dbt-freshness, namespace: observability }
+data:
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: Freshness
+        folder: "Data Quality"
+        interval: 5m
+        rules:
+          - uid: dq-stale
+            title: "dbt source stale"
+            condition: GT
+            data:
+              - refId: S
+                datasourceUid: prometheus
+                model: { expr: sum(dbt_source_stale) }
+              - refId: GT
+                datasourceUid: __expr__
+                model: { type: math, expression: "S > 0" }
+            annotations: { summary: "One or more sources are stale" }
+            labels: { severity: "warning" }
+

--- a/infra/k8s/observability/rule-dbt-tests.yaml
+++ b/infra/k8s/observability/rule-dbt-tests.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-rule-dbt-tests, namespace: observability }
+data:
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: DataQuality
+        folder: "Data Quality"
+        interval: 1m
+        rules:
+          - uid: dq-dbt-fail
+            title: "dbt tests failing"
+            condition: GT
+            data:
+              - refId: F
+                datasourceUid: prometheus
+                model:
+                  expr: dbt_tests_failed > 0
+              - refId: GT
+                datasourceUid: __expr__
+                model: { type: math, expression: "F > 0" }
+            annotations: { summary: "dbt tests failing" }
+            labels: { severity: "critical" }
+

--- a/infra/k8s/observability/rule-error-rate.yaml
+++ b/infra/k8s/observability/rule-error-rate.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-rule-error-rate, namespace: observability }
+data:
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: Errors
+        folder: "SLO"
+        interval: 1m
+        rules:
+          - uid: error-rate
+            title: "High error rate"
+            condition: GT
+            data:
+              - refId: R
+                datasourceUid: prometheus
+                relativeTimeRange: { from: 300, to: 0 }
+                model:
+                  expr: 100*sum(rate(spanmetrics_calls_total{service_name="search-api",http_status_code=~"5.."}[5m])) / clamp_min(sum(rate(spanmetrics_calls_total{service_name="search-api"}[5m])), 1e-6)
+              - refId: T
+                datasourceUid: __expr__
+                model: { type: threshold, expression: "2" }
+              - refId: GT
+                datasourceUid: __expr__
+                model: { type: math, expression: "R > T" }
+            annotations: { summary: "search-api error rate > 2% (5m)" }
+            labels: { severity: "critical", service: "search-api" }
+

--- a/infra/k8s/observability/rule-opa-deny.yaml
+++ b/infra/k8s/observability/rule-opa-deny.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-rule-opa-deny, namespace: observability }
+data:
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: OPA
+        folder: "OPA"
+        interval: 1m
+        rules:
+          - uid: opa-deny
+            title: "OPA deny spike"
+            condition: GT
+            data:
+              - refId: D
+                datasourceUid: clickhouse
+                relativeTimeRange: { from: 900, to: 0 }
+                model:
+                  query: "SELECT toStartOfMinute(ts) t, countIf(allowed=0) c FROM logs.opa_decisions WHERE ts > now()-interval 15 minute GROUP BY t ORDER BY t"
+              - refId: TH
+                datasourceUid: __expr__
+                model: { type: threshold, expression: "20" }
+              - refId: GT
+                datasourceUid: __expr__
+                model: { type: math, expression: "last(D) > TH" }
+            annotations: { summary: "denies/min > 20 in last 15m" }
+            labels: { severity: "warning" }
+

--- a/infra/k8s/observability/rule-slo-p95.yaml
+++ b/infra/k8s/observability/rule-slo-p95.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: grafana-rule-slo-p95, namespace: observability }
+data:
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: SLOs
+        folder: "SLO"
+        interval: 1m
+        rules:
+          - uid: slo-p95
+            title: "p95 latency breach"
+            condition: C
+            data:
+              - refId: A
+                datasourceUid: prometheus
+                relativeTimeRange: { from: 300, to: 0 }
+                model:
+                  expr: 1000*histogram_quantile(0.95, sum by (le) (rate(spanmetrics_latency_bucket{service_name="search-api"}[5m])))
+              - refId: B
+                datasourceUid: prometheus
+                relativeTimeRange: { from: 300, to: 0 }
+                model:
+                  expr: 300
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  type: math
+                  expression: A > B
+            annotations: { summary: "search-api p95 > 300ms (5m)" }
+            labels: { severity: "warning", service: "search-api" }
+


### PR DESCRIPTION
## Summary
- link OPA audit Grafana panel to Superset with filtered drilldown
- configure Grafana alerting via ConfigMaps and mount in deployment
- add alert rules for SLO latency, error rate, OPA denies, dbt tests and freshness
- cron job and exporter to expose dbt quality metrics and Prometheus scrape config

## Testing
- `python -m py_compile etl/dbt/tools/dbt_prom_exporter.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75d41aecc8324a0d1875673710b12