### PR TITLE
feat: analytics deep links and detail pages

### DIFF
--- a/.github/workflows/ci.yml.bak.1756853907
+++ b/.github/workflows/ci.yml.bak.1756853907
@@ -115,15 +115,3 @@ jobs:
       - name: Quick API smoke benchmark (search)
         run: |
           autocannon -d 10 -c 20 http://localhost:8080/search?q=test || true
-
-  superset:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - name: Lint Superset assets
-        run: |
-          pip install yamllint jq
-          yamllint apps/superset/assets/datasets/*.yaml
-          find apps/superset/assets -name '*.json' -exec jq . {} \;

--- a/apps/frontend/e2e/specs/analytics-deeplink.spec.ts
+++ b/apps/frontend/e2e/specs/analytics-deeplink.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('superset deeplink opens asset page', async ({ page }) => {
+  await page.goto('/test/superset-mock.html');
+  await page.click('[data-testid="deeplink"]');
+  await expect(page).toHaveURL(/\/asset\/A1/);
+  await expect(page.getByTestId('asset-page')).toBeVisible();
+});

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -19,7 +19,8 @@
     "isomorphic-unfetch": "^3.1.0",
     "next-auth": "^5.0.0",
     "cytoscape": "^3.28.0",
-    "react-cytoscapejs": "^1.3.1"
+    "react-cytoscapejs": "^1.3.1",
+    "recharts": "^2.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",

--- a/apps/frontend/pages/asset/[id].tsx
+++ b/apps/frontend/pages/asset/[id].tsx
@@ -1,0 +1,46 @@
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { TimeSeriesChart } from '../../src/components/analytics/TimeSeriesChart';
+import { OHLCChart } from '../../src/components/analytics/OHLCChart';
+import { GraphSnippet } from '../../src/components/analytics/GraphSnippet';
+import { NewsTimeline } from '../../src/components/analytics/NewsTimeline';
+import { EntityHeader } from '../../src/components/analytics/EntityHeader';
+import { fetchAsset, fetchAssetPrices, fetchGraph, fetchNews } from '../../src/lib/api';
+
+export default function AssetPage() {
+  const router = useRouter();
+  const { id, tab = 'chart', from, to } = router.query as { id: string; tab?: string; from?: string; to?: string };
+
+  const [asset, setAsset] = useState<any>();
+  const [prices, setPrices] = useState<any[]>([]);
+  const [graph, setGraph] = useState<any>({ nodes: [], edges: [] });
+  const [news, setNews] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (id) {
+      fetchAsset(id).then(setAsset).catch(() => {});
+      fetchAssetPrices(id, from, to).then(setPrices).catch(() => {});
+      fetchGraph(id, 1).then(setGraph).catch(() => {});
+      fetchNews(id).then(setNews).catch(() => {});
+    }
+  }, [id, from, to]);
+
+  return (
+    <div data-testid="asset-page">
+      {asset && <EntityHeader title={asset.name || id} type="Asset" />}
+      <nav>
+        <button onClick={() => router.push({ query: { id, tab: 'chart', from, to } })}>Kurs</button>
+        <button onClick={() => router.push({ query: { id, tab: 'graph', from, to } })}>Graph</button>
+        <button onClick={() => router.push({ query: { id, tab: 'news', from, to } })}>News</button>
+      </nav>
+      {tab === 'chart' && (
+        <>
+          <TimeSeriesChart data={prices.map(p => ({ ts: p.ts, value: p.close }))} />
+          <OHLCChart data={prices.map(p => ({ ts: p.ts, open: p.open, high: p.high, low: p.low, close: p.close }))} />
+        </>
+      )}
+      {tab === 'graph' && <GraphSnippet data={graph} />}
+      {tab === 'news' && <NewsTimeline items={news} />}
+    </div>
+  );
+}

--- a/apps/frontend/pages/person/[id].tsx
+++ b/apps/frontend/pages/person/[id].tsx
@@ -1,0 +1,34 @@
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { GraphSnippet } from '../../src/components/analytics/GraphSnippet';
+import { NewsTimeline } from '../../src/components/analytics/NewsTimeline';
+import { EntityHeader } from '../../src/components/analytics/EntityHeader';
+import { fetchAsset, fetchGraph, fetchNews } from '../../src/lib/api';
+
+export default function PersonPage() {
+  const router = useRouter();
+  const { id, tab = 'graph' } = router.query as { id: string; tab?: string };
+  const [person, setPerson] = useState<any>();
+  const [graph, setGraph] = useState<any>({ nodes: [], edges: [] });
+  const [news, setNews] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (id) {
+      fetchAsset(id).then(setPerson).catch(() => {});
+      fetchGraph(id, 1).then(setGraph).catch(() => {});
+      fetchNews(id).then(setNews).catch(() => {});
+    }
+  }, [id]);
+
+  return (
+    <div data-testid="person-page">
+      {person && <EntityHeader title={person.name || id} type="Person" />}
+      <nav>
+        <button onClick={() => router.push({ query: { id, tab: 'graph' } })}>Graph</button>
+        <button onClick={() => router.push({ query: { id, tab: 'news' } })}>News</button>
+      </nav>
+      {tab === 'graph' && <GraphSnippet data={graph} />}
+      {tab === 'news' && <NewsTimeline items={news} />}
+    </div>
+  );
+}

--- a/apps/frontend/public/test/superset-mock.html
+++ b/apps/frontend/public/test/superset-mock.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<a data-testid="deeplink" href="/asset/A1?from=2020-01-01&to=2020-01-31">Open asset A1</a>
+</body>
+</html>

--- a/apps/frontend/src/__tests__/AssetPage.test.tsx
+++ b/apps/frontend/src/__tests__/AssetPage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import AssetPage from '../../pages/asset/[id]';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { id: 'A1' }, push: vi.fn() })
+}));
+
+vi.mock('../../src/lib/api', () => ({
+  fetchAsset: async () => ({ name: 'A1' }),
+  fetchAssetPrices: async () => [{ ts: '1', open: 1, high: 1, low: 1, close: 1 }],
+  fetchGraph: async () => ({ nodes: [], edges: [] }),
+  fetchNews: async () => []
+}));
+
+test('loads header and default tab', async () => {
+  render(<AssetPage />);
+  expect(await screen.findByTestId('asset-page')).toBeInTheDocument();
+  expect(await screen.findByTestId('timeseries-chart')).toBeInTheDocument();
+});

--- a/apps/frontend/src/__tests__/GraphSnippet.test.tsx
+++ b/apps/frontend/src/__tests__/GraphSnippet.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { GraphSnippet } from '../components/analytics/GraphSnippet';
+
+test('renders nodes and click callback', () => {
+  const fn = vi.fn();
+  let cy: any;
+  render(
+    <GraphSnippet
+      data={{ nodes: [{ data: { id: 'a', label: 'A' } }], edges: [] }}
+      onNodeClick={fn}
+      cyRef={(c) => (cy = c)}
+    />
+  );
+  cy.$('#a').emit('tap');
+  expect(fn).toHaveBeenCalledWith('a');
+});

--- a/apps/frontend/src/__tests__/TimeSeriesChart.test.tsx
+++ b/apps/frontend/src/__tests__/TimeSeriesChart.test.tsx
@@ -1,0 +1,12 @@
+import { render, fireEvent } from '@testing-library/react';
+import { TimeSeriesChart } from '../components/analytics/TimeSeriesChart';
+
+test('renders and brush emits range', () => {
+  const fn = vi.fn();
+  const { container } = render(<TimeSeriesChart data={[{ ts: '1', value: 1 }, { ts: '2', value: 2 }]} onBrush={fn} />);
+  const brush = container.querySelector('.recharts-brush');
+  if (brush) {
+    fireEvent.change(brush, { target: { startIndex: 0, endIndex: 1 } });
+  }
+  expect(fn).toHaveBeenCalled();
+});

--- a/apps/frontend/src/components/analytics/EntityHeader.tsx
+++ b/apps/frontend/src/components/analytics/EntityHeader.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface Props {
+  title: string;
+  type: string;
+  supersetUrl?: string;
+}
+
+export const EntityHeader: React.FC<Props> = ({ title, type, supersetUrl }) => (
+  <header data-testid="entity-header">
+    <h1>{title}</h1>
+    <span>{type}</span>
+    {supersetUrl && (
+      <a href={supersetUrl} target="_blank" rel="noreferrer">
+        Open in Superset
+      </a>
+    )}
+  </header>
+);

--- a/apps/frontend/src/components/analytics/GraphSnippet.tsx
+++ b/apps/frontend/src/components/analytics/GraphSnippet.tsx
@@ -1,0 +1,25 @@
+import CytoscapeComponent from 'react-cytoscapejs';
+import React from 'react';
+
+export interface GraphData {
+  nodes: { data: { id: string; label: string } }[];
+  edges: { data: { source: string; target: string } }[];
+}
+interface Props {
+  data: GraphData;
+  onNodeClick?: (id: string) => void;
+  cyRef?: (cy: any) => void;
+}
+
+export const GraphSnippet: React.FC<Props> = ({ data, onNodeClick, cyRef }) => (
+  <div data-testid="graph-snippet" style={{ width: '100%', height: 300 }}>
+    <CytoscapeComponent
+      elements={[...data.nodes, ...data.edges]}
+      style={{ width: '100%', height: '100%' }}
+      cy={(cy) => {
+        cyRef && cyRef(cy);
+        cy.on('tap', 'node', (evt) => onNodeClick && onNodeClick(evt.target.id()));
+      }}
+    />
+  </div>
+);

--- a/apps/frontend/src/components/analytics/GraphSnippet.tsx.bak.1756853865
+++ b/apps/frontend/src/components/analytics/GraphSnippet.tsx.bak.1756853865
@@ -1,0 +1,23 @@
+import CytoscapeComponent from 'react-cytoscapejs';
+import React from 'react';
+
+export interface GraphData {
+  nodes: { data: { id: string; label: string } }[];
+  edges: { data: { source: string; target: string } }[];
+}
+interface Props {
+  data: GraphData;
+  onNodeClick?: (id: string) => void;
+}
+
+export const GraphSnippet: React.FC<Props> = ({ data, onNodeClick }) => (
+  <div data-testid="graph-snippet" style={{ width: '100%', height: 300 }}>
+    <CytoscapeComponent
+      elements={[...data.nodes, ...data.edges]}
+      style={{ width: '100%', height: '100%' }}
+      cy={(cy) => {
+        cy.on('tap', 'node', (evt) => onNodeClick && onNodeClick(evt.target.id()));
+      }}
+    />
+  </div>
+);

--- a/apps/frontend/src/components/analytics/NewsTimeline.tsx
+++ b/apps/frontend/src/components/analytics/NewsTimeline.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export interface NewsItem { id: string; title: string; date: string; url?: string }
+interface Props { items: NewsItem[]; onItemClick?: (id: string) => void }
+
+export const NewsTimeline: React.FC<Props> = ({ items, onItemClick }) => (
+  <ul data-testid="news-timeline">
+    {items.map((n) => (
+      <li key={n.id} onClick={() => onItemClick && onItemClick(n.id)}>
+        <span>{n.date}</span> - {n.title}
+      </li>
+    ))}
+  </ul>
+);

--- a/apps/frontend/src/components/analytics/OHLCChart.tsx
+++ b/apps/frontend/src/components/analytics/OHLCChart.tsx
@@ -1,0 +1,21 @@
+import { ComposedChart, XAxis, YAxis, Tooltip, CartesianGrid, Bar, Line, ResponsiveContainer } from 'recharts';
+import React from 'react';
+
+export interface OHLCPoint { ts: string; open: number; high: number; low: number; close: number }
+interface Props { data: OHLCPoint[] }
+
+export const OHLCChart: React.FC<Props> = ({ data }) => (
+  <div data-testid="ohlc-chart" style={{ width: '100%', height: 300 }}>
+    <ResponsiveContainer>
+      <ComposedChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="ts" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="high" fill="#82ca9d" />
+        <Bar dataKey="low" fill="#8884d8" />
+        <Line type="monotone" dataKey="close" stroke="#000" dot={false} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  </div>
+);

--- a/apps/frontend/src/components/analytics/TimeSeriesChart.tsx
+++ b/apps/frontend/src/components/analytics/TimeSeriesChart.tsx
@@ -1,0 +1,25 @@
+import { Line, LineChart, XAxis, YAxis, Tooltip, CartesianGrid, Brush, ResponsiveContainer } from 'recharts';
+import React from 'react';
+
+export interface SeriesPoint { ts: string; value: number }
+interface Props {
+  data: SeriesPoint[];
+  onBrush?: (range: [number, number]) => void;
+}
+
+export const TimeSeriesChart: React.FC<Props> = ({ data, onBrush }) => {
+  return (
+    <div data-testid="timeseries-chart" style={{ width: '100%', height: 300 }}>
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="ts" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" dot={false} />
+          {onBrush && <Brush dataKey="ts" onChange={(e) => e?.startIndex != null && e?.endIndex != null && onBrush([e.startIndex, e.endIndex])} />}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,0 +1,26 @@
+export async function fetchAsset(id: string) {
+  const res = await fetch(`/api/assets/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch asset');
+  return res.json();
+}
+
+export async function fetchAssetPrices(id: string, from?: string, to?: string) {
+  const params = new URLSearchParams();
+  if (from) params.append('from', from);
+  if (to) params.append('to', to);
+  const res = await fetch(`/api/assets/${id}/prices?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch prices');
+  return res.json();
+}
+
+export async function fetchGraph(id: string, depth = 1) {
+  const res = await fetch(`/api/graph?node=${id}&depth=${depth}`);
+  if (!res.ok) throw new Error('Failed to fetch graph');
+  return res.json();
+}
+
+export async function fetchNews(entityId: string) {
+  const res = await fetch(`/api/news?entity=${entityId}`);
+  if (!res.ok) throw new Error('Failed to fetch news');
+  return res.json();
+}

--- a/apps/superset/assets/README.md
+++ b/apps/superset/assets/README.md
@@ -1,0 +1,13 @@
+# Superset assets
+
+This directory contains dataset, chart and dashboard exports for Superset.
+
+Use `scripts/import.sh` to import them:
+
+```bash
+export SUPERTSET_TOKEN=... # API token
+export SUPERTSET_URL=https://superset.example.com
+./scripts/import.sh
+```
+
+The import script expects the Superset API to be reachable and uses the provided token.

--- a/apps/superset/assets/charts/markdown_info.json
+++ b/apps/superset/assets/charts/markdown_info.json
@@ -1,0 +1,7 @@
+{
+  "slice_name": "markdown_info",
+  "viz_type": "markdown",
+  "params": {
+    "markdown": "Use table links to open assets in InfoTerminal."
+  }
+}

--- a/apps/superset/assets/charts/ohlc.json
+++ b/apps/superset/assets/charts/ohlc.json
@@ -1,0 +1,16 @@
+{
+  "slice_name": "ohlc",
+  "viz_type": "candlestick",
+  "datasource": "finance_prices",
+  "params": {
+    "groupby": ["ts"],
+    "columns": {
+      "open": "open",
+      "high": "high",
+      "low": "low",
+      "close": "close"
+    },
+    "adhoc_filters": [],
+    "emit_filter": true
+  }
+}

--- a/apps/superset/assets/charts/table_links.json
+++ b/apps/superset/assets/charts/table_links.json
@@ -1,0 +1,18 @@
+{
+  "slice_name": "table_links",
+  "viz_type": "table",
+  "datasource": "finance_prices",
+  "params": {
+    "groupby": ["asset_id", "ts"],
+    "adhoc_filters": [],
+    "columns": ["asset_id", "ts", "it_url"],
+    "computed_columns": [
+      {
+        "column_name": "it_url",
+        "sql_expression": "concat('https://infoterminal.example.com/asset/', asset_id, '?from=', format_datetime(ts, 'YYYY-MM-DD'), '&to=', format_datetime(ts, 'YYYY-MM-DD'))"
+      }
+    ],
+    "allow_html": true,
+    "emit_filter": true
+  }
+}

--- a/apps/superset/assets/charts/time_close.json
+++ b/apps/superset/assets/charts/time_close.json
@@ -1,0 +1,13 @@
+{
+  "slice_name": "time_close",
+  "viz_type": "line",
+  "datasource": "finance_prices",
+  "params": {
+    "metrics": ["avg_close"],
+    "groupby": ["ts"],
+    "adhoc_filters": [],
+    "orderby": [["ts", true]],
+    "emit_filter": true,
+    "legend_position": "top"
+  }
+}

--- a/apps/superset/assets/charts/time_volatility.json
+++ b/apps/superset/assets/charts/time_volatility.json
@@ -1,0 +1,13 @@
+{
+  "slice_name": "time_volatility",
+  "viz_type": "line",
+  "datasource": "finance_prices",
+  "params": {
+    "metrics": ["vol_7d", "vol_30d"],
+    "groupby": ["ts"],
+    "adhoc_filters": [],
+    "orderby": [["ts", true]],
+    "emit_filter": true,
+    "legend_position": "top"
+  }
+}

--- a/apps/superset/assets/charts/time_volume.json
+++ b/apps/superset/assets/charts/time_volume.json
@@ -1,0 +1,13 @@
+{
+  "slice_name": "time_volume",
+  "viz_type": "bar",
+  "datasource": "finance_prices",
+  "params": {
+    "metrics": ["sum_volume"],
+    "groupby": ["ts"],
+    "adhoc_filters": [],
+    "orderby": [["ts", true]],
+    "emit_filter": true,
+    "legend_position": "top"
+  }
+}

--- a/apps/superset/assets/dashboard/analytics_prices.json
+++ b/apps/superset/assets/dashboard/analytics_prices.json
@@ -1,0 +1,50 @@
+{
+  "dashboard_title": "analytics_prices",
+  "description": "Price analytics dashboard with cross filtering",
+  "charts": [
+    "time_close",
+    "time_volume",
+    "time_volatility",
+    "ohlc",
+    "table_links",
+    "markdown_info"
+  ],
+  "metadata": {
+    "native_filter_configuration": [
+      {
+        "id": "nf_date",
+        "name": "Date Range",
+        "filterType": "date",
+        "targets": [
+          {
+            "datasetId": "finance_prices",
+            "column": "ts"
+          }
+        ]
+      },
+      {
+        "id": "nf_asset",
+        "name": "Asset",
+        "filterType": "select",
+        "targets": [
+          {
+            "datasetId": "finance_prices",
+            "column": "asset_id"
+          }
+        ]
+      },
+      {
+        "id": "nf_type",
+        "name": "Type",
+        "filterType": "select",
+        "targets": [
+          {
+            "datasetId": "finance_prices",
+            "column": "asset_id"
+          }
+        ]
+      }
+    ],
+    "cross_filters_enabled": true
+  }
+}

--- a/apps/superset/assets/datasets/finance_prices.yaml
+++ b/apps/superset/assets/datasets/finance_prices.yaml
@@ -1,0 +1,45 @@
+version: 1
+database: default
+dataset_name: finance_prices
+table_name: fct_price
+schema: public
+sql: |
+  select
+    asset_id,
+    ts::date as ts,
+    close,
+    volume,
+    stddev_samp(close) over (partition by asset_id order by ts rows between 6 preceding and current row) as vol_7d,
+    stddev_samp(close) over (partition by asset_id order by ts rows between 29 preceding and current row) as vol_30d,
+    open,
+    high,
+    low
+  from {{ ref('fct_price') }}
+columns:
+  - name: asset_id
+    type: TEXT
+  - name: ts
+    type: TIMESTAMP
+  - name: close
+    type: FLOAT
+  - name: volume
+    type: FLOAT
+  - name: vol_7d
+    type: FLOAT
+  - name: vol_30d
+    type: FLOAT
+  - name: open
+    type: FLOAT
+  - name: high
+    type: FLOAT
+  - name: low
+    type: FLOAT
+metrics:
+  - metric_name: avg_close
+    expression: AVG(close)
+  - metric_name: sum_volume
+    expression: SUM(volume)
+  - metric_name: vol_7d
+    expression: AVG(vol_7d)
+  - metric_name: vol_30d
+    expression: AVG(vol_30d)

--- a/apps/superset/assets/scripts/import.sh
+++ b/apps/superset/assets/scripts/import.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUPERTSET_URL="${SUPERTSET_URL:-http://localhost:8088}"
+SUPERTSET_TOKEN="${SUPERTSET_TOKEN:-}" 
+ASSETS_DIR="$(dirname "$0")/.."
+
+if [[ -z "$SUPERTSET_TOKEN" ]]; then
+  echo "SUPERTSET_TOKEN env var required" >&2
+  exit 1
+fi
+
+for kind in datasets charts dashboard; do
+  dir="$ASSETS_DIR/$kind"
+  if [[ -d "$dir" ]]; then
+    for file in "$dir"/*; do
+      echo "Importing $file"
+      curl -sf -X POST "$SUPERTSET_URL/api/v1/assets/import" \
+        -H "Authorization: Bearer $SUPERTSET_TOKEN" \
+        -F "formData=@$file" \
+        || echo "Failed to import $file"
+    done
+  fi
+  done

--- a/docs/dev/analytics_frontend.md
+++ b/docs/dev/analytics_frontend.md
@@ -1,0 +1,32 @@
+# Analytics frontend & Superset
+
+## Superset assets
+
+Assets live in `apps/superset/assets`. Import them via:
+
+```bash
+cd apps/superset/assets
+SUPERTSET_URL=https://superset.example.com \
+SUPERTSET_TOKEN=token ./scripts/import.sh
+```
+
+## Deep links
+
+Charts generate links of form:
+`https://INFOTERMINAL_BASE_URL/asset/{asset_id}?from=YYYY-MM-DD&to=YYYY-MM-DD&tab=chart`
+
+## Frontend pages
+
+- `/asset/[id]` – tabs: Kurs (chart & OHLC), Graph, News
+- `/person/[id]` – tabs: Graph, News
+
+Query parameters `from`, `to`, `tab` pre-select ranges and tabs.
+
+## Tests
+
+Run unit tests and e2e:
+
+```bash
+pnpm -w test
+pnpm -w e2e
+```

--- a/docs/dev/analytics_links.md
+++ b/docs/dev/analytics_links.md
@@ -1,0 +1,18 @@
+# Deep link schema
+
+Superset charts link to InfoTerminal frontend using the following templates:
+
+```
+https://INFOTERMINAL_BASE_URL/asset/{asset_id}?from=YYYY-MM-DD&to=YYYY-MM-DD&tab=chart
+https://INFOTERMINAL_BASE_URL/person/{person_id}?tab=graph
+```
+
+`from` and `to` are ISO dates limiting the displayed range. The optional `tab` parameter selects the initial tab (`chart`, `graph`, `news`).
+
+Example usage in Superset SQL:
+
+```
+concat('${INFOTERMINAL_BASE_URL}/asset/', asset_id,
+       '?from=', format_datetime(ts, 'YYYY-MM-DD'),
+       '&to=', format_datetime(ts, 'YYYY-MM-DD'))
+```


### PR DESCRIPTION
## Summary
- add Superset assets for finance price analytics and deep-link table
- implement frontend analytics components and asset/person pages
- document deep link schema and runbook

## Testing
- `pnpm -w build` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -w test` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -w e2e` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm build` *(fails: next: not found)*
- `pnpm install` *(fails: No matching version found for react-cytoscapejs@^1.3.1)*
- `pnpm test` *(fails: vitest: not found)*
- `pnpm e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b775b5f42c83249ba97de2193cbfe9