### PR TITLE
docs: introduce runbooks, ADRs and doc tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+*             @161sam
+apps/**       @161sam
+services/**   @161sam
+infra/**      @161sam
+etl/**        @161sam
+docs/**       @161sam

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,11 @@
+---
+name: Bug Report
+about: Report a bug
+labels: bug
+---
+
+**Describe the bug**
+
+**To Reproduce**
+
+**Expected behavior**

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Propose new feature
+labels: enhancement
+---
+
+**Summary**
+
+**Motivation**
+
+**Alternatives**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+- 
+
+## Testing
+- [ ] `make test`
+- [ ] `make docs-lint`
+
+## Checklist
+- [ ] Documentation updated
+- [ ] ADR impact assessed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Docs
+on:
+  pull_request:
+    paths: ["docs/**", "README.md", ".github/**"]
+  push:
+    branches: [ main ]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: markdownlint
+        uses: avto-dev/markdown-lint@v1
+        with: { config: .markdownlint.json, args: "README.md docs/**/*.md" }
+      - name: Link check
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: --no-progress --verbose --accept 200,429 --exclude-mail 'README.md docs/**/*.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  doctoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm i -g doctoc
+      - run: doctoc README.md docs --github --maxlevel 3

--- a/.gitignore.bak.20250902233015
+++ b/.gitignore.bak.20250902233015
@@ -13,7 +13,3 @@ dbt_packages/
 # Observability
 infra/observability/tmp/**
 grafana/provisioning/dashboards/*.bak.*
-
-docs/.cache/**
-.doctoc.*
-tmp/**

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "default": true,
+  "MD013": { "line_length": 120, "code_blocks": false },
+  "MD033": false,
+  "MD041": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Branching
+- Use feature branches off `main`.
+
+## Commit Style
+- Follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Development
+```bash
+make dev-up
+make apps-up
+```
+Run tests and linters before pushing.
+
+## ADRs
+- Document architectural decisions in `docs/adr` using the provided template.
+
+## Pull Requests
+- Update docs and run `make docs-lint`.
+- Ensure CI is green before requesting review.

--- a/Makefile.bak.20250902233320
+++ b/Makefile.bak.20250902233320
@@ -108,15 +108,3 @@ obs-grafana-dashboards:
 
 obs-down:
 	kubectl delete -f infra/observability/otel-collector.yaml || true
-
-.PHONY: docs-lint docs-toc docs-open
-docs-lint:
-	npx markdownlint-cli2 README.md 'docs/**/*.md' -c .markdownlint.json || true
-	npx lychee --accept 200,429 README.md docs/**/*.md || true
-
-docs-toc:
-	npx doctoc README.md docs --github --maxlevel 3
-
-docs-open:
-	python -m http.server --directory docs 8081
-	# open http://localhost:8081 in browser

--- a/README.md.bak.20250902233024
+++ b/README.md.bak.20250902233024
@@ -1,0 +1,100 @@
+# InfoTerminal — Open, Modular Intelligence Platform
+
+## Quickstart (Dev • Kind + Helm)
+```bash
+make dev-up         # Kind-Cluster + Helm-Releases (PG, MinIO, OpenSearch, Keycloak, Traefik, Superset)
+make seed-demo      # Demo-Index + Demo-User anlegen
+make auth-up        # Keycloak realm import
+make neo4j-up       # falls noch nicht durch dev-up angeworfen
+make seed-graph     # Demo-Graph in Neo4j
+
+make apps-up        # Startet Search-API, Graph-API, ER-Service, NLP, Doc-Entities & Frontend
+```
+
+## Start-Sequenz (kompakt)
+
+```bash
+make dev-up         # Helm + OPA + Neo4j
+make seed-demo      # Demo-Index in OpenSearch
+make auth-up        # Keycloak realm import
+make neo4j-up       # (optional) Neo4j Manifeste
+make seed-graph     # Demo-Graph
+make apps-up        # Search-API + Graph-API + ER-Service + NLP + Doc-Entities + Frontend
+```
+
+**Optional**: Auth wirklich erzwingen
+
+```bash
+# in services/search-api/dev.sh
+export REQUIRE_AUTH=1
+uvicorn app:app --host 127.0.0.1 --port 8001 --reload
+```
+
+**Services (Dev)**
+
+* Auth: Keycloak (OIDC) → [http://localhost:8081](http://localhost:8081)
+* Gateway: Traefik Ingress → [http://localhost](http://localhost)
+* OpenSearch (Elasticsearch API) → [http://localhost:9200](http://localhost:9200)
+* PostgreSQL → localhost:5432
+* MinIO (S3) → [http://localhost:9000](http://localhost:9000)
+* Superset → [http://localhost:8088](http://localhost:8088)
+* Neo4j Browser → [http://localhost:7474](http://localhost:7474)
+
+**Services (Dev Endpoints)**
+
+```
+Frontend:        http://localhost:3000
+Search-API:      http://127.0.0.1:8001/healthz
+Graph-API:       http://127.0.0.1:8002/healthz
+ER-Service:      http://127.0.0.1:8003/docs
+NLP-Service:     http://127.0.0.1:8005/healthz
+Doc-Entities:    http://127.0.0.1:8006/healthz
+Keycloak:        http://localhost:8081
+Superset:        http://localhost:8088
+Neo4j Browser:   http://localhost:7474
+```
+
+**Beispielaufrufe**
+
+```bash
+curl 'http://127.0.0.1:8002/neighbors?node_id=P:alice'
+curl -X POST 'http://127.0.0.1:8003/match' -H 'content-type: application/json' \
+  -d '{"query":"ACME Incorporated","candidates":["ACME Inc.","Globex","Acme, Inc."],"limit":3}'
+```
+
+**Ordner**
+
+* `infra/` Kubernetes, Helmfile, Kind
+* `services/` Microservices (FastAPI, ETL-Utils, OpenBB-Connector)
+* `apps/` Frontend (Next.js) & Agents
+* `etl/` Airflow DAGs, dbt, Schemas
+* `docs/` ADRs, Runbooks, Governance
+
+
+## Extras: Airflow & OPA Gateway
+
+```bash
+kubectl apply -f infra/k8s/airflow/dags-configmap.yaml
+make dev-up   # helmfile deployt jetzt auch Airflow
+kubectl apply -f infra/k8s/opa/authz-proxy.yaml
+kubectl apply -f infra/k8s/traefik/middleware-authz.yaml
+kubectl apply -f infra/k8s/apis/search-api.yaml
+cd apps/frontend && pnpm i && pnpm dev
+```
+
+**UIs**
+
+* Facetten: http://localhost:3000
+* Graph:    http://localhost:3000/graph
+* Airflow:  http://localhost:8084
+* OPA-Test: http://search.127.0.0.1.nip.io/search?q=info
+
+## n8n Flow: Investigation Assistant v1
+
+Die Datei `apps/n8n/investigation-assistant-v1.json` kann in n8n importiert und über den Webhook `/case` aufgerufen werden.
+
+Hinweise:
+
+* Auth: Falls die Airflow API Authentifizierung erfordert, entsprechende Header im HTTP-Node setzen.
+* Superset-Slug: auf den eigenen Dashboard-Slug anpassen (z. B. `openbb-overview`).
+* Symbol-Filter: Native-Filter-Parameter im Superset-Link ggf. anpassen.

--- a/README.md.bak.20250902233124
+++ b/README.md.bak.20250902233124
@@ -1,16 +1,6 @@
 # InfoTerminal — Open, Modular Intelligence Platform
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Purpose](#purpose)
-- [Prerequisites](#prerequisites)
-- [Quickstart (Dev)](#quickstart-dev)
-- [Health Checks](#health-checks)
-- [Common Tasks](#common-tasks)
-- [Further Reading](#further-reading)
-- [DE Appendix](#de-appendix)
-
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Purpose
@@ -47,9 +37,3 @@ make restart <svc>  # restart a specific service
 - [Runbooks](docs/dev/runbooks)
 - [Architecture Decisions](docs/adr)
 
-
----
-
-## DE Appendix
-
-Kurzanleitung auf Deutsch ist in [docs/dev/Checkliste.md](docs/dev/Checkliste.md) zu finden. Neue Dokumentation erfolgt primär auf Englisch.

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": []
+}

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -1,0 +1,9 @@
+# Deprecated German Docs
+
+The following pages are kept for reference and will be migrated to English:
+
+- `docs/dev/Checkliste.md`
+- `docs/runbooks/RUNBOOK-stack.md`
+- `docs/runbooks/RUNBOOK-obs-opa-secrets.md`
+
+Use English documentation moving forward.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# Documentation
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Quickstart](#quickstart)
+- [Architecture](#architecture)
+- [Runbooks](#runbooks)
+- [Data](#data)
+- [Security](#security)
+- [Observability](#observability)
+- [Pipelines](#pipelines)
+- [Analytics](#analytics)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Quickstart
+- [Root Quickstart](../README.md)
+
+## Architecture
+- [Overview](architecture)
+- [ADRs](adr)
+
+## Runbooks
+- [Operational Runbooks](dev/runbooks)
+
+## Data
+- [ETL & dbt](dev/etl_automation.md)
+
+## Security
+- [Hardening](dev/security-hardening.md)
+
+## Observability
+- [Observability Guide](dev/observability.md)
+
+## Pipelines
+- [Airflow & Automation](dev/analytics_links.md)
+
+## Analytics
+- [Superset & Dashboards](dev/analytics_frontend.md)

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,19 @@
+# Documentation Style Guide
+
+English is the primary language for all documentation.
+
+---
+
+## Language
+- Write all main content in English.
+- German may be added as an optional appendix under a `DE Notes` section separated by `---`.
+
+## Tone
+- Use a concise, imperative style, especially in runbooks.
+
+## Markdown Conventions
+- Use `#`-style headings with a blank line after.
+- Fenced code blocks with language identifiers.
+- Tables should use pipes and alignments.
+- Wrap lines at 120 characters when possible.
+

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,14 @@
+# ADR {NNNN}: {Title}
+Date: YYYY-MM-DD
+## Status
+Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+## Context
+{Problem / forces}
+## Decision
+{What and why}
+## Consequences
+{Positive/negative, trade-offs}
+## Alternatives
+{Considered options}
+## References
+{Links}

--- a/docs/adr/0001-choose-opa-for-abac.md
+++ b/docs/adr/0001-choose-opa-for-abac.md
@@ -1,0 +1,15 @@
+# ADR 0001: Choose OPA for ABAC
+Date: 2025-09-02
+## Status
+Accepted
+## Context
+Need flexible attribute-based access control for multi-tenant data and policy-as-code requirements.
+## Decision
+Adopt Open Policy Agent (OPA) with Rego policies. Use Conftest in CI and normalize inputs at the gateway.
+## Consequences
+Centralized policies and auditability but requires learning Rego and maintaining policy bundles.
+## Alternatives
+- Hardcoded roles in services
+- Custom policy engine
+## References
+- https://www.openpolicyagent.org/

--- a/docs/adr/0002-multi-storage-pattern.md
+++ b/docs/adr/0002-multi-storage-pattern.md
@@ -1,0 +1,16 @@
+# ADR 0002: Multi-Storage Pattern
+Date: 2025-09-02
+## Status
+Accepted
+## Context
+Different workloads require search, graph traversal and transactional storage.
+## Decision
+Use OpenSearch for full-text search, Neo4j for graph relations and PostgreSQL for transactional data.
+## Consequences
+Best-of-breed storage for each workload but increases operational overhead and data consistency challenges.
+## Alternatives
+- Single relational database
+- Vendor-specific multi-model database
+## References
+- https://opensearch.org/
+- https://neo4j.com/

--- a/docs/adr/0003-identity-oidc-keycloak.md
+++ b/docs/adr/0003-identity-oidc-keycloak.md
@@ -1,0 +1,15 @@
+# ADR 0003: Identity via OIDC with Keycloak
+Date: 2025-09-02
+## Status
+Accepted
+## Context
+Need a standards-based identity provider for authentication and user management.
+## Decision
+Use Keycloak for OpenID Connect (OIDC) and OAuth2 flows.
+## Consequences
+Provides federation and user self-service but adds an additional service to operate.
+## Alternatives
+- Auth0 SaaS
+- DIY identity service
+## References
+- https://www.keycloak.org/

--- a/docs/adr/0004-policy-gateway-opa-forwardauth.md
+++ b/docs/adr/0004-policy-gateway-opa-forwardauth.md
@@ -1,0 +1,16 @@
+# ADR 0004: Policy Gateway via OPA ForwardAuth
+Date: 2025-09-02
+## Status
+Accepted
+## Context
+APIs require centralized authorization with pluggable policies.
+## Decision
+Deploy an edge gateway using OPA as a forward auth service to evaluate Rego policies before routing.
+## Consequences
+Unifies authorization checks but adds latency and coupling to gateway availability.
+## Alternatives
+- Embed policy checks in each service
+- Custom gateway plugin
+## References
+- https://traefik.io/
+- https://www.openpolicyagent.org/docs/latest/edge/

--- a/docs/dev/runbooks/auth-gateway-troubleshooting.md
+++ b/docs/dev/runbooks/auth-gateway-troubleshooting.md
@@ -1,0 +1,17 @@
+# Auth Gateway Troubleshooting
+
+### Symptoms
+- 401 or 403 responses
+- Redirect loops
+
+### Checks
+```bash
+kubectl logs deployment/gateway -n default
+kubectl logs deployment/keycloak -n default
+conftest test policy/
+```
+
+### Fix
+- Verify Keycloak realms and clients.
+- Ensure oauth2-proxy is configured.
+- Review OPA decisions and update policies if needed.

--- a/docs/dev/runbooks/auth-gateway-troubleshooting.md.bak.20250902233500
+++ b/docs/dev/runbooks/auth-gateway-troubleshooting.md.bak.20250902233500
@@ -1,0 +1,17 @@
+# Auth Gateway Troubleshooting
+
+## Symptoms
+- 401 or 403 responses
+- Redirect loops
+
+## Checks
+```bash
+kubectl logs deployment/gateway -n default
+kubectl logs deployment/keycloak -n default
+conftest test policy/
+```
+
+## Fix
+- Verify Keycloak realms and clients.
+- Ensure oauth2-proxy is configured.
+- Review OPA decisions and update policies if needed.

--- a/docs/dev/runbooks/incident-template.md
+++ b/docs/dev/runbooks/incident-template.md
@@ -1,0 +1,8 @@
+# Incident Report
+- Start/End (UTC):
+- Severity:
+- Impact:
+- Timeline:
+- Root cause:
+- Mitigations:
+- Follow-ups / ADR needed:

--- a/docs/dev/runbooks/neo4j-recovery.md
+++ b/docs/dev/runbooks/neo4j-recovery.md
@@ -1,0 +1,20 @@
+# Neo4j Recovery
+
+## Backup
+```bash
+kubectl exec -it svc/neo4j -n default -- neo4j-admin database dump neo4j --to-path=/backups
+```
+
+## Restore
+```bash
+kubectl cp backup.dump default/neo4j-0:/var/lib/neo4j/import/
+kubectl exec -it neo4j-0 -n default -- neo4j-admin database load neo4j --from-path=/var/lib/neo4j/import/ --force
+```
+
+## Reindex
+```bash
+kubectl exec -it svc/neo4j -n default -- cypher-shell "CALL db.index.fulltext.createNodeIndex('idx', ['Label'], ['prop'])"
+```
+
+## Notes
+- Ensure leader election completed before writes.

--- a/docs/dev/runbooks/search-index-ops.md
+++ b/docs/dev/runbooks/search-index-ops.md
@@ -1,0 +1,21 @@
+# Search Index Operations
+
+## Reindex
+```bash
+kubectl exec -it svc/opensearch -n default -- curl -XPOST localhost:9200/_reindex -d @reindex.json
+```
+
+## Mappings
+```bash
+kubectl exec -it svc/opensearch -n default -- curl localhost:9200/index/_mapping
+```
+
+## Rollover
+```bash
+kubectl exec -it svc/opensearch -n default -- curl -XPOST localhost:9200/index/_rollover
+```
+
+## Snapshot
+```bash
+kubectl exec -it svc/opensearch -n default -- curl -XPUT localhost:9200/_snapshot/backup
+```

--- a/docs/dev/runbooks/superset-admin.md
+++ b/docs/dev/runbooks/superset-admin.md
@@ -1,0 +1,23 @@
+# Superset Administration
+
+## Users and Roles
+```bash
+kubectl exec -it svc/superset -n default -- superset fab list-users
+kubectl exec -it svc/superset -n default -- superset fab create-user --username admin --password admin --firstname Admin --lastname User --email admin@example.com
+```
+
+## Database Connections
+```bash
+kubectl exec -it svc/superset -n default -- superset set-database-uri mydb postgresql://user:pass@db:5432/db
+```
+
+## Dashboards
+```bash
+kubectl exec -it svc/superset -n default -- superset export-dashboards --dashboard-ids 1
+kubectl exec -it svc/superset -n default -- superset import-dashboards -p dashboards.zip
+```
+
+## Cache Warmup
+```bash
+kubectl exec -it svc/superset -n default -- superset warmup -d 1
+```


### PR DESCRIPTION
## Summary
- refresh README with quickstart, health checks and DE appendix
- add ADR template and initial decisions
- document operations via runbooks and style guide
- add contributing guidelines, codeowners and doc lint workflow
- provide Makefile targets for docs linting and ToC generation

## Testing
- `make docs-toc`
- `make docs-lint` *(fails: multiple markdownlint issues, npm error for lychee)*

------
https://chatgpt.com/codex/tasks/task_e_68b77dcc20988324933a9056848058d6