### PR TITLE
chore: enforce utf-8 encoding in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ main ]
 
+env:
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
+
 jobs:
   backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure GitHub Actions runs with UTF-8 locale to avoid encoding failures

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: missing document start, spacing, line length issues)*

------
https://chatgpt.com/codex/tasks/task_e_68b7805321c48324b69fe83a6abfbf0d