### PR TITLE
feat: add nlp-service to dev stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,19 @@ dev-up: ## (Erweitert) nach helmfile apply auch OPA & Neo4j
 	@echo "→ Deploy OPA & Neo4j (manifests)"
 	@kubectl apply -f infra/k8s/opa/opa.yaml
 	@kubectl apply -f infra/k8s/neo4j/neo4j.yaml
+	@docker compose up -d --build nlp-service
 
 dev-down:
 	@helmfile -f infra/helmfile/helmfile.yaml destroy || true
 	@kind delete cluster --name $(KIND_CLUSTER) || true
+	@docker compose down || true
 
 apps-up:
 	@uv run --python 3.11 -q --directory services/search-api ./dev.sh &
 	@uv run --python 3.11 -q --directory services/graph-api ./dev.sh &
 	@uv run --python 3.11 -q --directory services/entity-resolution ./dev.sh &
 	@uv run --python 3.11 -q --directory services/graph-views ./dev.sh &
-	@uv run --python 3.11 -q --directory services/nlp ./dev.sh &
+	@uv run --python 3.11 -q --directory services/nlp-service uvicorn app:app --host 0.0.0.0 --port 8003 &
 	@uv run --python 3.11 -q --directory services/doc-entities ./dev.sh &
 	@pnpm --dir apps/frontend dev &
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ make web-up        # Next.js Dev-Server (alternativ: npm run dev im web/)
 
 ---
 
+## 🧠 NLP-Service
+
+Der NLP-Service stellt Named Entity Recognition und Text-Zusammenfassung bereit.
+
+```bash
+curl -X POST http://localhost:8003/ner -H "Content-Type: application/json" -d '{"text":"Barack Obama was born in Hawaii."}'
+curl -X POST http://localhost:8003/summarize -H "Content-Type: application/json" -d '{"text":"..."}'
+```
+
 ## 🔌 Wichtige Endpunkte (Beispiele)
 
 ```http

--- a/apps/frontend/pages/index.tsx
+++ b/apps/frontend/pages/index.tsx
@@ -33,6 +33,7 @@ export default function Home() {
       <div style={{display:"flex", gap:8, marginBottom:12}}>
         {!session ? <button onClick={()=>signIn()}>Login</button> : <button onClick={()=>signOut()}>Logout</button>}
         <span>{session?.user?.name || session?.user?.email}</span>
+        <a href="/nlp">NLP</a>
       </div>
 
       <form onSubmit={search} style={{display:"flex", gap:8, marginBottom:10}}>

--- a/apps/frontend/pages/nlp.tsx
+++ b/apps/frontend/pages/nlp.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react"
+
+export default function NLPPage() {
+  const [text, setText] = useState("")
+  const [ner, setNer] = useState<any | null>(null)
+  const [summary, setSummary] = useState<string>("")
+  const [error, setError] = useState<string>("")
+
+  const callNer = async () => {
+    setError("")
+    setSummary("")
+    try {
+      const r = await fetch("http://127.0.0.1:8003/ner", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text })
+      })
+      if (!r.ok) throw new Error("bad")
+      const j = await r.json()
+      setNer(j)
+    } catch (e) {
+      setError("NLP-Service nicht verfügbar")
+    }
+  }
+
+  const callSummarize = async () => {
+    setError("")
+    setNer(null)
+    try {
+      const r = await fetch("http://127.0.0.1:8003/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text })
+      })
+      if (!r.ok) throw new Error("bad")
+      const j = await r.json()
+      setSummary(j.summary)
+    } catch (e) {
+      setError("NLP-Service nicht verfügbar")
+    }
+  }
+
+  return (
+    <main style={{maxWidth:800, margin:"40px auto", fontFamily:"ui-sans-serif"}}>
+      <h1>NLP</h1>
+      <textarea value={text} onChange={e=>setText(e.target.value)} rows={5} style={{width:"100%", padding:8}} placeholder="Text eingeben…" />
+      <div style={{display:"flex", gap:8, marginTop:8}}>
+        <button onClick={callNer}>Entitäten extrahieren</button>
+        <button onClick={callSummarize}>Zusammenfassen</button>
+      </div>
+      {error && <div style={{color:"red", marginTop:8}}>{error}</div>}
+      {ner && (
+        <pre style={{background:"#f7f7f7", padding:8, marginTop:8}}>{JSON.stringify(ner, null, 2)}</pre>
+      )}
+      {summary && (
+        <div style={{marginTop:8}}>
+          <b>Zusammenfassung:</b>
+          <p>{summary}</p>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  nlp-service:
+    build: ./services/nlp-service
+    ports:
+      - "8003:8003"
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8003/healthz').getcode()==200 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/docs/dev/Checkliste.md
+++ b/docs/dev/Checkliste.md
@@ -6,7 +6,7 @@
 * **OPA** — 🟨 Policies (RBAC + ABAC), Tests (opa test) und Bundle-Modus vorhanden; noch Feinschliff für Service-Inputs & CI Gate Coverage
 * **Search** — ✅ Search-API (FastAPI) + Facetten + Frontend-Suche (Next.js)
 * **Graph** — ✅ Graph-API (Neo4j) + Viewer (Basis & GraphX mit Expand/Pin/Save); Server-Side Views (CRUD + Share) ✅
-* **AI Layer & Agents** — ⬜️ NLP-Service/Agent-Flows noch nicht verdrahtet
+* **AI Layer & Agents** — 🟨 NLP-Service (NER/Summary) erreichbar; Agent-Flows offen
 * **Dokumentenmanagement (Aleph)** — 🟨 Aleph UI + Worker/Redis laufen; kein automatischer NiFi-Ingest, keine NER-Crosslinks im Viewer
 * **ETL** — 🟨 NiFi UI + Registry stehen; Demo-Template deployed; Airflow via Helm + DAG-ConfigMap ✅; KPO-DAG + CronJob für OpenBB 🟨 (Image/secret polishing)
 * **Analytics** — 🟨 Superset Helm + OIDC + Preset-Job + dbt→Superset Sync; RLS-Beispiel (Gamma) gesetzt; weitere Datasets/Charts offen
@@ -106,10 +106,12 @@
 
 ## 9) AI Layer & Agents
 
-*Mini-Blueprint:* FastAPI-Service (`services/nlp`) für NER/Embeddings/Summary + optionale `/resolve`-Route; n8n/Flowise für Agent-Flows.
+*Mini-Blueprint:* FastAPI-Service (`services/nlp-service`) für NER/Embeddings/Summary + optionale `/resolve`-Route; n8n/Flowise für Agent-Flows.
 
-* [ ] `services/nlp` deployen (NER, Embed, Summarize)
-  *Befehl:* `uv run --python 3.11 -q --directory services/nlp ./dev.sh`
+* [ ] `services/nlp-service` deployen (NER, Embed, Summarize)
+  *Befehl:* `uv run --python 3.11 -q --directory services/nlp-service uvicorn app:app --port 8003`
+* [ ] NLP-Service Health
+  *URL:* [127.0.0.1:8003](http://127.0.0.1:8003/healthz)
 * [ ] Search-Rerank aktivieren (Cosine Top-N)
     *Env:* `export RERANK=1 NLP_URL=http://127.0.0.1:8005`
 * [ ] Entity-Resolver `/resolve` aktiv

--- a/tests/test_nlp_integration.py
+++ b/tests/test_nlp_integration.py
@@ -1,0 +1,24 @@
+import os
+import importlib.util
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+service_path = Path(__file__).resolve().parents[1] / "services" / "nlp-service" / "app.py"
+spec = importlib.util.spec_from_file_location("nlp_service_app", service_path)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+os.environ["ALLOW_TEST_MODE"] = "1"
+client = TestClient(module.app)
+
+def test_ner_returns_entity():
+    resp = client.post("/ner", json={"text": "Barack Obama was born in Hawaii."})
+    data = resp.json()
+    assert "entities" in data
+    assert len(data["entities"]) >= 1
+
+def test_summarize_returns_string():
+    resp = client.post("/summarize", json={"text": "This is a test text for summarization."})
+    data = resp.json()
+    assert isinstance(data.get("summary"), str)
+    assert data["summary"]


### PR DESCRIPTION
## Summary
- add docker compose service for nlp with healthcheck
- wire nlp-service into Makefile and frontend
- document usage and add basic integration tests

## Testing
- `uv run --python 3.11 -q -- pytest tests/test_nlp_integration.py`
- `pnpm --dir apps/frontend test` *(fails: vitest: not found)*
- `pnpm --dir apps/frontend install` *(fails: No matching version found for react-cytoscapejs@^1.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ea646c10832495da3fe65b6ad2ed