### PR TITLE
feat: add observability stack with prometheus and grafana

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,21 +95,16 @@ etl-superset-warmup:
 	python apps/superset/scripts/warmup_refresh.py
 
 
-.PHONY: obs-up obs-down obs-grafana-dashboards
+.PHONY: obs-up obs-down obs-reload
 
 obs-up:
-	kubectl apply -f infra/observability/otel-collector.yaml
-	# helm install/upgrade prometheus, loki, promtail, tempo with provided values
-	# e.g.: helm upgrade --install prom prometheus-community/prometheus -f infra/observability/prometheus/values.yaml
-	#       helm upgrade --install loki grafana/loki -f infra/observability/loki/values.yaml
-	#       helm upgrade --install promtail grafana/promtail -f infra/observability/promtail/values.yaml
-	#       helm upgrade --install tempo grafana/tempo -f infra/observability/tempo/values.yaml
-
-obs-grafana-dashboards:
-	# copy dashboards to Grafana mount path or use ConfigMap sidecar (implementation note)
+	docker compose up -d prometheus grafana
 
 obs-down:
-        kubectl delete -f infra/observability/otel-collector.yaml || true
+	docker compose rm -sf prometheus grafana
+
+obs-reload:
+	curl -X POST http://localhost:9090/-/reload || true
 
 nifi-template-import:
         @bash scripts/nifi_template_import.sh

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ make web-up        # Next.js Dev-Server (alternativ: npm run dev im web/)
 
 > **Hinweis:** Die Port-URLs können je nach Setup variieren. Siehe `docs/dev/checklist.md` / `.env.example`.
 
+## Monitoring
+
+Prometheus: http://localhost:9090
+
+Grafana:    http://localhost:3001  (admin/admin)
+
+Dashboards: Folder "InfoTerminal" → API Overview, Search Rerank, Doc Resolver
+
 
 ---
 

--- a/deploy/grafana/dashboards/api-overview.json
+++ b/deploy/grafana/dashboards/api-overview.json
@@ -1,0 +1,36 @@
+{
+  "uid": "api-overview",
+  "title": "API Overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Requests/sec",
+      "targets": [
+        { "expr": "rate(http_requests_total[1m])", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency p95",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le,handler))", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Error Rate",
+      "targets": [
+        { "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "targets": [
+        { "expr": "up", "datasource": "Prometheus" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/doc-resolver.json
+++ b/deploy/grafana/dashboards/doc-resolver.json
@@ -1,0 +1,29 @@
+{
+  "uid": "doc-resolver",
+  "title": "Doc Resolver",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Resolver Runs/min",
+      "targets": [
+        { "expr": "increase(resolver_runs_total[5m])", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Entities by Status",
+      "targets": [
+        { "expr": "increase(resolver_entities_total[5m]) by (status)", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Resolver Latency p95",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(resolver_latency_seconds_bucket[5m])) by (le))", "datasource": "Prometheus" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/dashboards/search-rerank.json
+++ b/deploy/grafana/dashboards/search-rerank.json
@@ -1,0 +1,37 @@
+{
+  "uid": "search-rerank",
+  "title": "Search Rerank",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Rerank Requests",
+      "targets": [
+        { "expr": "increase(search_rerank_requests_total[5m])", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Rerank Latency p95",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(search_rerank_latency_seconds_bucket[5m])) by (le))", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Search Latency p95",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum(rate(search_latency_seconds_bucket[5m])) by (le))", "datasource": "Prometheus" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Toggle Impact",
+      "targets": [
+        { "expr": "sum(rate(search_requests_total{rerank=\"1\"}[5m]))", "datasource": "Prometheus" },
+        { "expr": "sum(rate(search_requests_total{rerank=\"0\"}[5m]))", "datasource": "Prometheus" }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'InfoTerminal Dashboards'
+    orgId: 1
+    folder: 'InfoTerminal'
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 10s
+  scrape_timeout: 5s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'search-api'
+    static_configs:
+      - targets: ['search-api:8001']
+    metrics_path: /metrics
+
+  - job_name: 'graph-api'
+    static_configs:
+      - targets: ['graph-api:8002']
+    metrics_path: /metrics
+
+  - job_name: 'doc-entities'
+    static_configs:
+      - targets: ['doc-entities:8006']
+    metrics_path: /metrics
+
+  - job_name: 'nlp-service'
+    static_configs:
+      - targets: ['nlp-service:8003']
+    metrics_path: /metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,34 @@ services:
       timeout: 10s
       retries: 5
 
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=7d
+    volumes:
+      - ./deploy/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prom_data:/prometheus
+    ports: ["9090:9090"]
+    depends_on:
+      - search-api
+      - graph-api
+      - doc-entities
+      - nlp-service
+
+  grafana:
+    image: grafana/grafana:10.4.5
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports: ["3001:3000"]
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning
+      - ./deploy/grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - prometheus
+
 volumes:
   pgdata:
   aleph:
+  prom_data:

--- a/services/doc-entities/metrics.py
+++ b/services/doc-entities/metrics.py
@@ -1,0 +1,13 @@
+from prometheus_client import Counter, Histogram
+
+RESOLVER_RUNS = Counter(
+    "resolver_runs_total", "Resolver runs total", ["mode"]
+)
+RESOLVER_ENTS = Counter(
+    "resolver_entities_total", "Entities processed", ["status"]
+)
+RESOLVER_LAT = Histogram(
+    "resolver_latency_seconds",
+    "Resolver run latency",
+    buckets=[0.1, 0.25, 0.5, 1, 2, 5, 10],
+)

--- a/services/doc-entities/pyproject.toml
+++ b/services/doc-entities/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.46b0",
     "opentelemetry-instrumentation-requests>=0.46b0",
     "opentelemetry-instrumentation-logging>=0.46b0",
-    "prometheus-client>=0.20",
-    "starlette-exporter>=0.15",
+    "prometheus-client==0.20.*",
+    "prometheus-fastapi-instrumentator==6.1.*",
     "sqlalchemy>=2.0",
     "alembic>=1.13",
 ]

--- a/services/doc-entities/resolver.py
+++ b/services/doc-entities/resolver.py
@@ -5,17 +5,17 @@ resolve them against Neo4j. The functions here are stubs so that the API
 can schedule work without crashing.
 """
 from typing import Iterable
+import time
+
+from .metrics import RESOLVER_RUNS, RESOLVER_ENTS, RESOLVER_LAT
 
 
-def resolve_entities(entity_ids: Iterable[str]) -> None:
-    """Placeholder resolver.
-
-    Parameters
-    ----------
-    entity_ids: Iterable[str]
-        IDs of entities that should be resolved. The current implementation
-        is a no-op and simply exists so that future workers can hook in.
-    """
-    # TODO: implement resolver logic in v0.1.0
+def resolve_entities(entity_ids: Iterable[str], mode: str = "async") -> None:
+    """Placeholder resolver with metrics hooks."""
+    RESOLVER_RUNS.labels(mode=mode).inc()
+    start = time.perf_counter()
+    n_unmatched = 0
     for _ in entity_ids:
-        pass
+        n_unmatched += 1
+    RESOLVER_ENTS.labels(status="unmatched").inc(n_unmatched)
+    RESOLVER_LAT.observe(time.perf_counter() - start)

--- a/services/graph-api/app.py
+++ b/services/graph-api/app.py
@@ -6,9 +6,22 @@ except Exception:
 import os
 from typing import Optional
 from fastapi import FastAPI, Depends, Header, HTTPException
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentation
-from prometheus_client import make_asgi_app
+try:
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+except Exception:  # pragma: no cover - optional
+    class FastAPIInstrumentor:  # type: ignore
+        def instrument_app(self, app):
+            return app
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
+import importlib.util
+from pathlib import Path
+
+SERVICE_DIR = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location("graph_metrics", SERVICE_DIR / "metrics.py")
+_metrics = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_metrics)  # type: ignore
+GRAPH_REQS = _metrics.GRAPH_REQS
 from neo4j import GraphDatabase
 from auth import user_from_token
 from opa import allow
@@ -21,8 +34,12 @@ REQUIRE_AUTH = os.getenv("REQUIRE_AUTH","0") == "1"
 driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASS))
 
 app = FastAPI(title="InfoTerminal Graph API", version="0.1.0")
-FastAPIInstrumentation().instrument_app(app)
-app.mount("/metrics", make_asgi_app())
+FastAPIInstrumentor().instrument_app(app)
+instrumentator = Instrumentator().instrument(app)
+
+@app.on_event("startup")
+async def _startup() -> None:
+    instrumentator.expose(app, include_in_schema=False, should_gzip=True)
 app.add_middleware(
   CORSMiddleware,
   allow_origins=["http://localhost:3000","http://127.0.0.1:3000"],
@@ -45,6 +62,7 @@ def health():
 def neighbors(node_id: str, limit: int = 20, user=Depends(oidc_user)):
     if not allow(user,"read",{"classification":"public","type":"graph"}):
         raise HTTPException(403,"forbidden")
+    GRAPH_REQS.labels(endpoint="neighbors").inc()
     q = """
     MATCH (n {id: $id})-[r]-(m)
     RETURN n, type(r) as rel, m
@@ -65,6 +83,7 @@ def neighbors(node_id: str, limit: int = 20, user=Depends(oidc_user)):
 def shortest_path(src: str, dst: str, maxlen:int=6, user=Depends(oidc_user)):
     if not allow(user,"read",{"classification":"public","type":"graph"}):
         raise HTTPException(403,"forbidden")
+    GRAPH_REQS.labels(endpoint="shortest_path").inc()
     q = """
     MATCH (a {id:$src}), (b {id:$dst}),
     p = shortestPath((a)-[*..$maxlen]-(b))

--- a/services/graph-api/metrics.py
+++ b/services/graph-api/metrics.py
@@ -1,0 +1,3 @@
+from prometheus_client import Counter
+
+GRAPH_REQS = Counter("graph_requests_total", "Graph requests", ["endpoint"])

--- a/services/graph-api/pyproject.toml
+++ b/services/graph-api/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
   "opentelemetry-instrumentation-fastapi>=0.46b0",
   "opentelemetry-instrumentation-requests>=0.46b0",
   "opentelemetry-instrumentation-logging>=0.46b0",
-  "prometheus-client>=0.20",
-  "starlette-exporter>=0.15",
+  "prometheus-client==0.20.*",
+  "prometheus-fastapi-instrumentator==6.1.*",
 ]
 
 [project.optional-dependencies]

--- a/services/nlp-service/app.py
+++ b/services/nlp-service/app.py
@@ -2,8 +2,24 @@ import os
 from typing import List
 from fastapi import FastAPI
 from pydantic import BaseModel
+from prometheus_fastapi_instrumentator import Instrumentator
+import importlib.util
+from pathlib import Path
+
+SERVICE_DIR = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location("nlp_metrics", SERVICE_DIR / "metrics.py")
+_metrics = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_metrics)  # type: ignore
+NLP_REQS = _metrics.NLP_REQS
+NLP_LATENCY = _metrics.NLP_LATENCY
 
 app = FastAPI()
+instrumentator = Instrumentator().instrument(app)
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    instrumentator.expose(app, include_in_schema=False, should_gzip=True)
 
 # Lazy holders for NLP models
 _nlp = None
@@ -39,32 +55,36 @@ class TextRequest(BaseModel):
 
 @app.post("/ner")
 async def ner_endpoint(payload: TextRequest):
-    nlp = get_nlp()
-    text = payload.text
-    if os.getenv("ALLOW_TEST_MODE"):
-        first = text.split()[0] if text.split() else ""
-        return {"entities": [{"text": first, "label": "TEST", "start": 0, "end": len(first)}]}
-    doc = nlp(text)
-    entities: List[dict] = []
-    for ent in doc.ents:
-        entities.append({
-            "text": ent.text,
-            "label": ent.label_,
-            "start": ent.start_char,
-            "end": ent.end_char,
-        })
-    return {"entities": entities}
+    NLP_REQS.labels(type="ner").inc()
+    with NLP_LATENCY.labels(type="ner").time():
+        nlp = get_nlp()
+        text = payload.text
+        if os.getenv("ALLOW_TEST_MODE"):
+            first = text.split()[0] if text.split() else ""
+            return {"entities": [{"text": first, "label": "TEST", "start": 0, "end": len(first)}]}
+        doc = nlp(text)
+        entities: List[dict] = []
+        for ent in doc.ents:
+            entities.append({
+                "text": ent.text,
+                "label": ent.label_,
+                "start": ent.start_char,
+                "end": ent.end_char,
+            })
+        return {"entities": entities}
 
 
 @app.post("/summarize")
 async def summarize_endpoint(payload: TextRequest):
-    summarizer = get_summarizer()
-    text = payload.text
-    if os.getenv("ALLOW_TEST_MODE"):
-        summary = " ".join(text.split()[:5])
-        return {"summary": summary}
-    result = summarizer(text)
-    return {"summary": result[0]["summary_text"]}
+    NLP_REQS.labels(type="summarize").inc()
+    with NLP_LATENCY.labels(type="summarize").time():
+        summarizer = get_summarizer()
+        text = payload.text
+        if os.getenv("ALLOW_TEST_MODE"):
+            summary = " ".join(text.split()[:5])
+            return {"summary": summary}
+        result = summarizer(text)
+        return {"summary": result[0]["summary_text"]}
 
 
 @app.get("/healthz")

--- a/services/nlp-service/metrics.py
+++ b/services/nlp-service/metrics.py
@@ -1,0 +1,9 @@
+from prometheus_client import Counter, Histogram
+
+NLP_REQS = Counter("nlp_requests_total", "NLP requests", ["type"])
+NLP_LATENCY = Histogram(
+    "nlp_latency_seconds",
+    "NLP latency",
+    ["type"],
+    buckets=[0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+)

--- a/services/nlp-service/requirements.txt
+++ b/services/nlp-service/requirements.txt
@@ -2,3 +2,8 @@ fastapi==0.111.0
 uvicorn==0.30.1
 spacy==3.7.2
 transformers==4.40.2
+prometheus-client==0.20.*
+prometheus-fastapi-instrumentator==6.1.*
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi
+opentelemetry-exporter-otlp

--- a/services/search-api/app/main.py
+++ b/services/search-api/app/main.py
@@ -11,18 +11,20 @@ import numpy as np
 
 from fastapi import FastAPI, Depends, HTTPException, Header, Query, Response
 try:
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentation
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 except Exception:  # pragma: no cover - optional
-    class FastAPIInstrumentation:  # type: ignore
+    class FastAPIInstrumentor:  # type: ignore
         def instrument_app(self, app):
             return app
 
-try:
-    from prometheus_client import make_asgi_app
-except Exception:  # pragma: no cover - optional
-    def make_asgi_app():
-        from fastapi import FastAPI
-        return FastAPI()
+from prometheus_fastapi_instrumentator import Instrumentator
+from .metrics import (
+    SEARCH_ERRORS,
+    SEARCH_LATENCY,
+    SEARCH_REQUESTS,
+    RERANK_LATENCY,
+    RERANK_REQS,
+)
 
 from fastapi.middleware.cors import CORSMiddleware
 from opensearchpy import OpenSearch
@@ -36,8 +38,12 @@ settings = Settings()
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="InfoTerminal Search API", version="0.3.0")
-FastAPIInstrumentation().instrument_app(app)
-app.mount("/metrics", make_asgi_app())
+FastAPIInstrumentor().instrument_app(app)
+instrumentator = Instrumentator().instrument(app)
+
+@app.on_event("startup")
+async def _startup() -> None:
+    instrumentator.expose(app, include_in_schema=False, should_gzip=True)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
@@ -95,81 +101,88 @@ def search(
 ):
     if not allow(user, "read", {"classification": "public", "type": "search"}):
         raise HTTPException(403, "forbidden")
+    do_rerank = False
     try:
         entity_types = [s for s in (entity_type.split(",") if entity_type else []) if s]
-        query_body = {
-            "bool": {
-                "must": [{"multi_match": {"query": q, "fields": ["title^2", "body", "entities.name^3"]}}],
-                "filter": [_filters_query(entity_types)],
+        with SEARCH_LATENCY.time():
+            query_body = {
+                "bool": {
+                    "must": [{"multi_match": {"query": q, "fields": ["title^2", "body", "entities.name^3"]}}],
+                    "filter": [_filters_query(entity_types)],
+                }
             }
-        }
-        res = client.search(index=settings.os_index, body={"query": query_body, "aggs": _aggs(), "size": 20})
-        hits = res.get("hits", {}).get("hits", [])
-        aggs = res.get("aggregations", {})
-        facets = {
-            "entity_types": [
-                {"key": b["key"], "count": b["doc_count"]}
-                for b in aggs.get("entity_types", {}).get("types", {}).get("buckets", [])
-            ]
-        }
-        items = [{"id": h["_id"], "score": h["_score"], **h["_source"]} for h in hits]
-
-        do_rerank = (
-            settings.rerank_enabled
-            and (rerank == 1 or x_rerank == 1)
-            and len(items) > 1
-            and q and len(q.strip()) > 2
-        )
-        if do_rerank:
-            start = time.time()
-            topk = min(settings.rerank_topk, len(items))
-            provider = rr.EmbeddingProvider(settings.rerank_model)
-            try:
-                query_text = q
-                query_vec = rr.get_query_embedding(provider, query_text)
-                doc_texts = [
-                    (items[i].get("snippet") or items[i].get("body") or items[i].get("title") or "")[:1024]
-                    for i in range(topk)
+            res = client.search(index=settings.os_index, body={"query": query_body, "aggs": _aggs(), "size": 20})
+            hits = res.get("hits", {}).get("hits", [])
+            aggs = res.get("aggregations", {})
+            facets = {
+                "entity_types": [
+                    {"key": b["key"], "count": b["doc_count"]}
+                    for b in aggs.get("entity_types", {}).get("types", {}).get("buckets", [])
                 ]
-                doc_vecs = np.vstack([
-                    rr.get_doc_embedding(provider, items[i]["id"], doc_texts[i]) for i in range(topk)
-                ])
-                ranks = rr.cosine_rank(query_vec, doc_vecs)
-                cos_scores = [r[1] for r in ranks]
-                bm25_scores = [items[r[0]]["score"] for r in ranks]
-                norm_cos = rr.normalize(cos_scores)
-                norm_bm = rr.normalize(bm25_scores)
-                blended = [0.7 * norm_cos[i] + 0.3 * norm_bm[i] for i in range(len(ranks))]
-                scored = []
-                for (idx, cos), final in zip(ranks, blended):
-                    item = items[idx]
-                    item.setdefault("meta", {})["rerank"] = {
-                        "cosine": float(cos),
-                        "blended": float(final),
-                    }
-                    item["score"] = float(final)
-                    scored.append((idx, final))
-                # reorder
-                sorted_items = [items[i] for i, _ in sorted(scored, key=lambda x: x[1], reverse=True)]
-                reranked_items = sorted_items + items[topk:]
-                elapsed = int((time.time() - start) * 1000)
-                if elapsed <= settings.rerank_timeout_ms:
-                    items = reranked_items
-                    response.headers["X-Reranked"] = "1"
-                    response.headers["X-Rerank-TopK"] = str(topk)
-                    response.headers["X-Rerank-Model"] = settings.rerank_model
-                    response.headers["X-Rerank-TimeMs"] = str(elapsed)
-                    logger.debug(
-                        "rerank topk=%s elapsed=%sms cache=%s",
-                        topk,
-                        elapsed,
-                        rr.cache_stats,
-                    )
-                else:
-                    logger.warning("rerank timeout after %sms", elapsed)
-            except Exception as e:
-                logger.warning("rerank failed: %s", e)
+            }
+            items = [{"id": h["_id"], "score": h["_score"], **h["_source"]} for h in hits]
+
+            do_rerank = (
+                settings.rerank_enabled
+                and (rerank == 1 or x_rerank == 1)
+                and len(items) > 1
+                and q and len(q.strip()) > 2
+            )
+            if do_rerank:
+                RERANK_REQS.inc()
+                with RERANK_LATENCY.time():
+                    start = time.time()
+                    topk = min(settings.rerank_topk, len(items))
+                    provider = rr.EmbeddingProvider(settings.rerank_model)
+                    try:
+                        query_text = q
+                        query_vec = rr.get_query_embedding(provider, query_text)
+                        doc_texts = [
+                            (items[i].get("snippet") or items[i].get("body") or items[i].get("title") or "")[:1024]
+                            for i in range(topk)
+                        ]
+                        doc_vecs = np.vstack([
+                            rr.get_doc_embedding(provider, items[i]["id"], doc_texts[i]) for i in range(topk)
+                        ])
+                        ranks = rr.cosine_rank(query_vec, doc_vecs)
+                        cos_scores = [r[1] for r in ranks]
+                        bm25_scores = [items[r[0]]["score"] for r in ranks]
+                        norm_cos = rr.normalize(cos_scores)
+                        norm_bm = rr.normalize(bm25_scores)
+                        blended = [0.7 * norm_cos[i] + 0.3 * norm_bm[i] for i in range(len(ranks))]
+                        scored = []
+                        for (idx, cos), final in zip(ranks, blended):
+                            item = items[idx]
+                            item.setdefault("meta", {})["rerank"] = {
+                                "cosine": float(cos),
+                                "blended": float(final),
+                            }
+                            item["score"] = float(final)
+                            scored.append((idx, final))
+                        # reorder
+                        sorted_items = [items[i] for i, _ in sorted(scored, key=lambda x: x[1], reverse=True)]
+                        reranked_items = sorted_items + items[topk:]
+                        elapsed = int((time.time() - start) * 1000)
+                        if elapsed <= settings.rerank_timeout_ms:
+                            items = reranked_items
+                            response.headers["X-Reranked"] = "1"
+                            response.headers["X-Rerank-TopK"] = str(topk)
+                            response.headers["X-Rerank-Model"] = settings.rerank_model
+                            response.headers["X-Rerank-TimeMs"] = str(elapsed)
+                            logger.debug(
+                                "rerank topk=%s elapsed=%sms cache=%s",
+                                topk,
+                                elapsed,
+                                rr.cache_stats,
+                            )
+                        else:
+                            logger.warning("rerank timeout after %sms", elapsed)
+                    except Exception as e:
+                        logger.warning("rerank failed: %s", e)
 
         return {"results": items, "facets": facets}
     except Exception as e:
+        SEARCH_ERRORS.labels(type=e.__class__.__name__).inc()
         raise HTTPException(500, f"search error: {e}")
+    finally:
+        SEARCH_REQUESTS.labels(rerank="1" if do_rerank else "0").inc()

--- a/services/search-api/app/metrics.py
+++ b/services/search-api/app/metrics.py
@@ -1,0 +1,21 @@
+from prometheus_client import Counter, Histogram
+
+SEARCH_REQUESTS = Counter(
+    "search_requests_total", "Total search requests", ["rerank"]
+)
+SEARCH_ERRORS = Counter(
+    "search_errors_total", "Search errors", ["type"]
+)
+SEARCH_LATENCY = Histogram(
+    "search_latency_seconds",
+    "Search latency seconds",
+    buckets=[0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+)
+RERANK_REQS = Counter(
+    "search_rerank_requests_total", "Rerank requests"
+)
+RERANK_LATENCY = Histogram(
+    "search_rerank_latency_seconds",
+    "Rerank latency",
+    buckets=[0.05, 0.1, 0.25, 0.5, 1, 2],
+)

--- a/services/search-api/requirements.txt
+++ b/services/search-api/requirements.txt
@@ -6,3 +6,8 @@ httpx>=0.27
 cachetools>=5.3
 numpy>=1.24
 sentence-transformers==2.2.2
+prometheus-client==0.20.*
+prometheus-fastapi-instrumentator==6.1.*
+opentelemetry-sdk
+opentelemetry-instrumentation-fastapi
+opentelemetry-exporter-otlp


### PR DESCRIPTION
## Summary
- expose Prometheus metrics in all FastAPI services
- add Prometheus and Grafana to docker compose and provisioning
- document new monitoring stack and usage

## Testing
- `pytest` *(fails: No module named 'pydantic_settings'; No module named 'sqlalchemy'; test module name collisions)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fb91a96c8324ba09e8348c2715c9