### PR TITLE
feat: add global service health widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.*
 !.env.example
+!**/.env.example
 secrets/
 
 # ETL-related ignores

--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ make web-up        # Next.js Dev-Server (alternativ: npm run dev im web/)
 
 ## Monitoring
 
+![Header Health Badge](docs/img/health-badge.svg)
+
 Prometheus: http://localhost:9090
 
 Grafana:    http://localhost:3001  (admin/admin)
 
 Dashboards: Folder "InfoTerminal" → API Overview, Search Rerank, Doc Resolver
+
+> Wenn das Badge rot ist, prüfe die docker compose Logs der betreffenden Services.
 
 
 ---

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SEARCH_API=http://localhost:8001
+NEXT_PUBLIC_GRAPH_API=http://localhost:8002
+NEXT_PUBLIC_DOCENTITIES_API=http://localhost:8006
+NEXT_PUBLIC_NLP_API=http://localhost:8003
+NEXT_PUBLIC_GRAFANA_URL=http://localhost:3001

--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -1,0 +1,13 @@
+export const SEARCH_API = process.env.NEXT_PUBLIC_SEARCH_API || '';
+if (!SEARCH_API) console.warn('NEXT_PUBLIC_SEARCH_API is not set');
+
+export const GRAPH_API = process.env.NEXT_PUBLIC_GRAPH_API || '';
+if (!GRAPH_API) console.warn('NEXT_PUBLIC_GRAPH_API is not set');
+
+export const DOCENTITIES_API = process.env.NEXT_PUBLIC_DOCENTITIES_API || '';
+if (!DOCENTITIES_API) console.warn('NEXT_PUBLIC_DOCENTITIES_API is not set');
+
+export const NLP_API = process.env.NEXT_PUBLIC_NLP_API || '';
+if (!NLP_API) console.warn('NEXT_PUBLIC_NLP_API is not set');
+
+export const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || '';

--- a/apps/frontend/pages/api/health.ts
+++ b/apps/frontend/pages/api/health.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { SEARCH_API, GRAPH_API, DOCENTITIES_API, NLP_API } from '../../lib/config';
+
+type ServiceState = 'ok' | 'degraded' | 'down' | 'unreachable';
+export type HealthResponse = {
+  timestamp: string;
+  services: {
+    search: { state: ServiceState; latencyMs: number | null; info?: any };
+    graph: { state: ServiceState; latencyMs: number | null; info?: any };
+    docentities: { state: ServiceState; latencyMs: number | null; info?: any };
+    nlp: { state: ServiceState; latencyMs: number | null; info?: any };
+  };
+};
+
+async function ping(url: string): Promise<{ state: ServiceState; latencyMs: number | null; info?: any }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  const start = Date.now();
+  try {
+    const res = await fetch(url + '/healthz', { signal: controller.signal });
+    const latencyMs = Date.now() - start;
+    clearTimeout(timeout);
+    if (!res.ok) {
+      return { state: 'unreachable', latencyMs };
+    }
+    const info = await res.json().catch(() => ({}));
+    let state: ServiceState = 'ok';
+    if (info.status === 'degraded') state = 'degraded';
+    else if (info.status === 'down') state = 'down';
+    else if (info.status !== 'ok') state = 'unreachable';
+    return { state, latencyMs, info };
+  } catch {
+    return { state: 'unreachable', latencyMs: null };
+  }
+}
+
+export async function getHealth(): Promise<HealthResponse> {
+  const services = await Promise.all([
+    ping(SEARCH_API),
+    ping(GRAPH_API),
+    ping(DOCENTITIES_API),
+    ping(NLP_API),
+  ]);
+  return {
+    timestamp: new Date().toISOString(),
+    services: {
+      search: services[0],
+      graph: services[1],
+      docentities: services[2],
+      nlp: services[3],
+    },
+  };
+}
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const data = await getHealth();
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json(data);
+}

--- a/apps/frontend/pages/index.tsx
+++ b/apps/frontend/pages/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react"
 import { signIn, signOut, useSession } from "next-auth/react"
+import Header from "../src/components/layout/Header"
 
 type FacetBucket = { key: string; count: number }
 export default function Home() {
@@ -28,6 +29,8 @@ export default function Home() {
   }
 
   return (
+    <>
+    <Header />
     <main style={{maxWidth:1100, margin:"40px auto", fontFamily:"ui-sans-serif"}}>
       <h1>InfoTerminal</h1>
       <div style={{display:"flex", gap:8, marginBottom:12}}>
@@ -72,5 +75,6 @@ export default function Home() {
         </section>
       </div>
     </main>
+    </>
   )
 }

--- a/apps/frontend/pages/search.tsx
+++ b/apps/frontend/pages/search.tsx
@@ -6,6 +6,7 @@ import Pagination from '../src/components/search/Pagination';
 import SortAndRerank from '../src/components/search/SortAndRerank';
 import { useSearchParams } from '../src/hooks/useSearchParams';
 import { useSearch } from '../src/hooks/useSearch';
+import Header from '../src/components/layout/Header';
 
 export default function SearchPage() {
   const { params, set, replaceAll } = useSearchParams();
@@ -65,6 +66,7 @@ export default function SearchPage() {
 
   return (
     <div>
+      <Header />
       <SearchBox
         value={q}
         onChange={(v) => set('q', v)}

--- a/apps/frontend/src/__tests__/GlobalHealth.spec.tsx
+++ b/apps/frontend/src/__tests__/GlobalHealth.spec.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import GlobalHealth from '../components/health/GlobalHealth';
+import { vi } from 'vitest';
+
+describe('GlobalHealth', () => {
+  it('shows green when all ok and opens popover', async () => {
+    const mock = {
+      timestamp: new Date().toISOString(),
+      services: {
+        search: { state: 'ok', latencyMs: 10 },
+        graph: { state: 'ok', latencyMs: 12 },
+        docentities: { state: 'ok', latencyMs: 8 },
+        nlp: { state: 'ok', latencyMs: 9 },
+      },
+    };
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mock });
+    render(<GlobalHealth pollIntervalMs={100000} />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const btn = screen.getByLabelText('service-health');
+    const dot = btn.querySelector('span span');
+    expect(dot?.className).toContain('bg-green-500');
+    await fireEvent.click(btn);
+    expect(screen.getByText(/search/i)).toBeInTheDocument();
+    expect(screen.getByText(/graph/i)).toBeInTheDocument();
+    expect(screen.getByText(/docentities/i)).toBeInTheDocument();
+    expect(screen.getByText(/nlp/i)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/health-api.spec.ts
+++ b/apps/frontend/src/__tests__/health-api.spec.ts
@@ -1,0 +1,20 @@
+import { vi, expect, it } from 'vitest';
+import { getHealth } from '../../pages/api/health';
+
+it('aggregates service states', async () => {
+  const responses = [
+    { ok: true, json: async () => ({ status: 'ok' }) },
+    { ok: true, json: async () => ({ status: 'degraded' }) },
+    Promise.reject(new Error('fail')),
+    { ok: false, json: async () => ({}) },
+  ];
+  const fetchMock = vi.fn();
+  responses.forEach((r) => fetchMock.mockResolvedValueOnce(r as any));
+  global.fetch = fetchMock as any;
+
+  const res = await getHealth();
+  expect(res.services.search.state).toBe('ok');
+  expect(res.services.graph.state).toBe('degraded');
+  expect(res.services.docentities.state).toBe('unreachable');
+  expect(res.services.nlp.state).toBe('unreachable');
+});

--- a/apps/frontend/src/components/health/GlobalHealth.tsx
+++ b/apps/frontend/src/components/health/GlobalHealth.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import StatusDot from './StatusDot';
+import HealthPopover from './HealthPopover';
+import { useHealth } from '../../hooks/useHealth';
+
+export const GlobalHealth: React.FC<{ pollIntervalMs?: number }> = ({ pollIntervalMs = 15000 }) => {
+  const { data, error, refresh, stateAggregate } = useHealth(pollIntervalMs);
+  const [open, setOpen] = useState(false);
+
+  const aggState = error ? 'unreachable' : stateAggregate;
+  const tooltip =
+    aggState === 'ok'
+      ? 'All systems operational'
+      : aggState === 'degraded'
+      ? 'Issues detected'
+      : 'Issues detected';
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="service-health"
+        title={tooltip}
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center"
+      >
+        <StatusDot state={aggState} />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 bg-white shadow-lg rounded z-50">
+          <HealthPopover data={data} onRefresh={refresh} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GlobalHealth;

--- a/apps/frontend/src/components/health/HealthPopover.tsx
+++ b/apps/frontend/src/components/health/HealthPopover.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ServiceHealthCard from './ServiceHealthCard';
+import type { HealthResponse } from '../../../pages/api/health';
+import { GRAFANA_URL } from '../../../lib/config';
+
+interface Props {
+  data: HealthResponse | null;
+  onRefresh: () => void;
+}
+
+export const HealthPopover: React.FC<Props> = ({ data, onRefresh }) => {
+  const services = data?.services;
+  return (
+    <div className="p-4 w-64">
+      <div className="grid grid-cols-1 gap-2">
+        {services && (
+          <>
+            <ServiceHealthCard name="search" state={services.search.state} latencyMs={services.search.latencyMs} />
+            <ServiceHealthCard name="graph" state={services.graph.state} latencyMs={services.graph.latencyMs} />
+            <ServiceHealthCard name="docentities" state={services.docentities.state} latencyMs={services.docentities.latencyMs} />
+            <ServiceHealthCard name="nlp" state={services.nlp.state} latencyMs={services.nlp.latencyMs} />
+          </>
+        )}
+      </div>
+      <div className="mt-4 flex justify-end gap-4 text-sm">
+        {GRAFANA_URL && (
+          <a href={GRAFANA_URL} target="_blank" rel="noreferrer" className="text-blue-600">
+            Open Grafana
+          </a>
+        )}
+        <button onClick={onRefresh} className="underline">
+          Force refresh
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default HealthPopover;

--- a/apps/frontend/src/components/health/ServiceHealthCard.tsx
+++ b/apps/frontend/src/components/health/ServiceHealthCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import StatusDot, { ServiceState } from './StatusDot';
+
+export interface Props {
+  name: string;
+  state: ServiceState;
+  latencyMs: number | null;
+  onClick?: () => void;
+}
+
+const badgeColor: Record<ServiceState, string> = {
+  ok: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  down: 'bg-red-500',
+  unreachable: 'bg-gray-400'
+};
+
+export const ServiceHealthCard: React.FC<Props> = ({ name, state, latencyMs, onClick }) => (
+  <div onClick={onClick} className="p-3 rounded shadow-md cursor-pointer flex items-center justify-between">
+    <div className="flex items-center gap-2">
+      <StatusDot state={state} />
+      <span className="font-medium">{name}</span>
+    </div>
+    <div className="flex items-center gap-2 text-sm">
+      <span>{latencyMs !== null ? `${latencyMs} ms` : '–'}</span>
+      <span className={`text-white px-2 py-0.5 rounded ${badgeColor[state]}`}>{state}</span>
+    </div>
+  </div>
+);
+
+export default ServiceHealthCard;

--- a/apps/frontend/src/components/health/StatusDot.tsx
+++ b/apps/frontend/src/components/health/StatusDot.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export type ServiceState = 'ok' | 'degraded' | 'down' | 'unreachable';
+
+const colorMap: Record<ServiceState, string> = {
+  ok: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  down: 'bg-red-500',
+  unreachable: 'bg-gray-400'
+};
+
+export const StatusDot: React.FC<{ state: ServiceState; label?: string }> = ({ state, label }) => (
+  <span className="inline-flex items-center">
+    <span className={`w-3 h-3 rounded-full ${colorMap[state]}`}></span>
+    {label && <span className="ml-1">{label}</span>}
+  </span>
+);
+
+export default StatusDot;

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import GlobalHealth from '../health/GlobalHealth';
+
+const Header: React.FC = () => (
+  <header className="flex items-center justify-between px-4 py-2 shadow-md">
+    <a href="/" className="font-bold">InfoTerminal</a>
+    <GlobalHealth />
+  </header>
+);
+
+export default Header;

--- a/apps/frontend/src/hooks/useHealth.ts
+++ b/apps/frontend/src/hooks/useHealth.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+import type { HealthResponse } from '../../pages/api/health';
+import type { ServiceState } from '../components/health/StatusDot';
+
+export function useHealth(intervalMs: number = 15000) {
+  const [data, setData] = useState<HealthResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchHealth = async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      setLoading(true);
+      const res = await fetch('/api/health', { signal: controller.signal });
+      if (!res.ok) throw new Error(res.statusText);
+      const json = await res.json();
+      setData(json);
+      setError(null);
+    } catch (e: any) {
+      if (e.name === 'AbortError') return;
+      setError(e);
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      fetchHealth();
+    }, 250);
+    return () => {
+      clearTimeout(t);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(fetchHealth, intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  const refresh = () => fetchHealth();
+
+  const aggregate = (): ServiceState => {
+    const states = Object.values(data?.services || {}).map((s) => s.state);
+    if (states.some((s) => s === 'down' || s === 'unreachable')) return 'unreachable';
+    if (states.some((s) => s === 'degraded')) return 'degraded';
+    return 'ok';
+  };
+
+  return { data, loading, error, refresh, stateAggregate: aggregate() };
+}

--- a/docs/dev/frontend-docs.md
+++ b/docs/dev/frontend-docs.md
@@ -1,0 +1,23 @@
+# Frontend Health Monitoring
+
+The frontend exposes `GET /api/health` which pings core backend services and returns their status and latency.
+
+```ts
+GET /api/health -> {
+  timestamp: string;
+  services: {
+    search: { state: 'ok'|'degraded'|'down'|'unreachable'; latencyMs: number|null };
+    graph: { state: 'ok'|'degraded'|'down'|'unreachable'; latencyMs: number|null };
+    docentities: { state: 'ok'|'degraded'|'down'|'unreachable'; latencyMs: number|null };
+    nlp: { state: 'ok'|'degraded'|'down'|'unreachable'; latencyMs: number|null };
+  }
+}
+```
+
+The `GlobalHealth` widget polls this API every 15 seconds by default. States map to colored dots:
+
+- **ok** – green
+- **degraded** – yellow
+- **down/unreachable** – red or gray
+
+If the badge turns red, use the "Force refresh" option or check the Docker compose logs for the affected service.

--- a/docs/img/health-badge.svg
+++ b/docs/img/health-badge.svg
@@ -1,0 +1,5 @@
+<svg width="400" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="400" height="40" fill="#f8f8f8" stroke="#ddd" />
+  <text x="16" y="25" font-size="16" font-family="sans-serif" fill="#111">InfoTerminal</text>
+  <circle cx="380" cy="20" r="8" fill="#22c55e" />
+</svg>

--- a/services/doc-entities/app.py
+++ b/services/doc-entities/app.py
@@ -60,8 +60,9 @@ class AnnotReq(BaseModel):
 
 
 @app.get("/healthz")
-def health() -> Dict[str, bool]:
-    return {"ok": True}
+def health() -> Dict[str, str]:
+    """Simple health-check endpoint."""
+    return {"status": "ok"}
 
 
 @app.post("/annotate")


### PR DESCRIPTION
## Summary
- expose standard `/healthz` in doc-entities service
- add configurable service URLs and health aggregator API
- implement global health widget with polling, popover and navbar integration
- document health API and add README badge screenshot using SVG

## Testing
- `npx vitest run src/__tests__/health-api.spec.ts src/__tests__/GlobalHealth.spec.tsx`
- `pytest -c /dev/null services/search-api/tests/test_health.py`
- `pytest -c /dev/null services/graph-api/tests/test_health.py`
- `pytest -c /dev/null services/nlp-service/tests/test_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff6192f48324b14cf6299fc2bf22