### PR TITLE
feat: add entity badges and quick filters

### DIFF
--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -11,3 +11,6 @@ export const NLP_API = process.env.NEXT_PUBLIC_NLP_API || '';
 if (!NLP_API) console.warn('NEXT_PUBLIC_NLP_API is not set');
 
 export const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || '';
+
+export const SEARCH_FILTER_MODE =
+  process.env.NEXT_PUBLIC_SEARCH_FILTER_MODE || 'quote_query';

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,7 +22,8 @@
     "react": "18.3.1",
     "react-cytoscapejs": "^2.0.0",
     "react-dom": "18.3.1",
-    "recharts": "^2.9.0"
+    "recharts": "^2.9.0",
+    "lucide-react": "^0.542.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/apps/frontend/pages/docs/[id].tsx
+++ b/apps/frontend/pages/docs/[id].tsx
@@ -3,9 +3,12 @@ import { useEffect, useState } from 'react';
 import EntityHighlighter from '../../src/components/docs/EntityHighlighter';
 import DocCard from '../../src/components/docs/DocCard';
 import { DocRecord } from '../../src/types/docs';
+import EntityBadgeList, { BadgeItem } from '../../src/components/entities/EntityBadgeList';
+import { uniqueEntities } from '../../src/lib/entities';
 
 export default function DocPage() {
-  const { query } = useRouter();
+  const router = useRouter();
+  const { query } = router;
   const id = (query.id as string) || '';
   const [doc, setDoc] = useState<DocRecord | null>(null);
   const [error, setError] = useState<string>('');
@@ -23,10 +26,26 @@ export default function DocPage() {
 
   if (error) return <main>{error}</main>;
   if (!doc) return <main>Lade...</main>;
+
+  const badges: BadgeItem[] = uniqueEntities(
+    doc.entities.map((e) => ({ label: e.label, value: e.text || '' })),
+  );
+
+  const handleBadgeClick = (item: BadgeItem) => {
+    if (item.value) router.push(`/search?value=${encodeURIComponent(item.value)}`);
+    else router.push(`/search?entity=${encodeURIComponent(item.label)}`);
+  };
+
   return (
-    <main style={{ maxWidth: 800, margin: '1rem auto' }}>
-      <DocCard doc={doc} />
-      <EntityHighlighter text={doc.text} entities={doc.entities} />
+    <main style={{ maxWidth: 800, margin: '1rem auto', display: 'flex', gap: '1rem' }}>
+      <div style={{ flex: 1 }}>
+        <DocCard doc={doc} />
+        <EntityHighlighter text={doc.text} entities={doc.entities} />
+      </div>
+      <aside style={{ width: 200 }}>
+        <h4>Entitäten</h4>
+        <EntityBadgeList items={badges} onBadgeClick={handleBadgeClick} />
+      </aside>
     </main>
   );
 }

--- a/apps/frontend/pages/search.tsx
+++ b/apps/frontend/pages/search.tsx
@@ -31,11 +31,18 @@ export default function SearchPage() {
     : entityParam
     ? [entityParam as string]
     : undefined;
+  const valueParam = params.value;
+  const value = Array.isArray(valueParam)
+    ? (valueParam as string[])
+    : valueParam
+    ? [valueParam as string]
+    : undefined;
 
   const { data, loading, error } = useSearch({
     q,
     filters,
     entity,
+    value,
     sort,
     rerank,
     page,
@@ -55,6 +62,18 @@ export default function SearchPage() {
     const key = `filter.${facet}`;
     const arr = (filters[facet] || []).filter((v) => v !== value);
     set(key, arr.join(',') || undefined);
+    set('page', 1);
+  };
+
+  const handleRemoveEntity = (label: string) => {
+    const arr = (entity || []).filter((e) => e !== label);
+    set('entity', arr.length ? arr : undefined);
+    set('page', 1);
+  };
+
+  const handleRemoveValue = (v: string) => {
+    const arr = (value || []).filter((e) => e !== v);
+    set('value', arr.length ? arr : undefined);
     set('page', 1);
   };
 
@@ -79,7 +98,15 @@ export default function SearchPage() {
         rerank={rerank}
         onRerankToggle={(v) => set('rerank', v ? '1' : undefined)}
       />
-      <FilterChips filters={filters} onRemove={handleRemoveChip} onClearAll={handleClearAll} />
+      <FilterChips
+        filters={filters}
+        entity={entity}
+        value={value}
+        onRemove={handleRemoveChip}
+        onRemoveEntity={handleRemoveEntity}
+        onRemoveValue={handleRemoveValue}
+        onClearAll={handleClearAll}
+      />
       {error && <div>Error: {String(error.message)}</div>}
       {!error && data && data.total === 0 && <div>No results</div>}
       <div style={{ display: 'flex' }}>

--- a/apps/frontend/src/__tests__/EntityBadge.spec.tsx
+++ b/apps/frontend/src/__tests__/EntityBadge.spec.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render } from '@testing-library/react';
+import EntityBadge from '../components/entities/EntityBadge';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('EntityBadge', () => {
+  it('renders label', () => {
+    const { getByText } = render(<EntityBadge label="Person" />);
+    expect(getByText('Person')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(<EntityBadge label="Organization" clickable onClick={onClick} />);
+    fireEvent.click(getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders as link when href provided', () => {
+    const { container } = render(<EntityBadge label="Location" href="/search" />);
+    const a = container.querySelector('a');
+    expect(a).toHaveAttribute('href', '/search');
+  });
+});

--- a/apps/frontend/src/__tests__/entities.spec.ts
+++ b/apps/frontend/src/__tests__/entities.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLabel, uniqueEntities } from '../lib/entities';
+
+describe('entities utils', () => {
+  it('normalizes labels', () => {
+    expect(normalizeLabel('PER')).toBe('Person');
+    expect(normalizeLabel('org')).toBe('Organization');
+    expect(normalizeLabel('Loc')).toBe('Location');
+    expect(normalizeLabel('email')).toBe('Email');
+    expect(normalizeLabel('ipv4')).toBe('IP');
+    expect(normalizeLabel('unknown')).toBe('Misc');
+  });
+
+  it('deduplicates entities case-insensitively', () => {
+    const result = uniqueEntities([
+      { label: 'PER', value: 'Alice' },
+      { label: 'Person', value: 'alice' },
+      { label: 'ORG', value: 'ACME' },
+    ]);
+    expect(result).toEqual([
+      { label: 'Organization', value: 'ACME', count: 1 },
+      { label: 'Person', value: 'Alice', count: 2 },
+    ]);
+  });
+});

--- a/apps/frontend/src/__tests__/search-quickfilters.spec.tsx
+++ b/apps/frontend/src/__tests__/search-quickfilters.spec.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildSearchUrl } from '../lib/searchNav';
+
+describe('buildSearchUrl', () => {
+  it('adds entity and value params', () => {
+    const url = buildSearchUrl({}, { addEntity: 'Person' });
+    expect(url).toBe('/search?entity=Person');
+    const url2 = buildSearchUrl({ entity: ['Person'] }, { addValue: 'ACME' });
+    expect(url2).toBe('/search?entity=Person&value=ACME');
+  });
+
+  it('removes params', () => {
+    const url = buildSearchUrl({ entity: ['Person'], value: ['ACME'] }, { remove: { entity: 'Person' } });
+    expect(url).toBe('/search?value=ACME');
+  });
+});

--- a/apps/frontend/src/components/entities/EntityBadge.tsx
+++ b/apps/frontend/src/components/entities/EntityBadge.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { ENTITY_COLORS, EntityLabel } from '../../lib/entities';
+import {
+  User,
+  Building2,
+  MapPin,
+  AtSign,
+  Globe,
+  Network,
+  Tag,
+} from 'lucide-react';
+
+type Props = {
+  label: EntityLabel;
+  value?: string;
+  size?: 'sm' | 'md';
+  clickable?: boolean;
+  onClick?: () => void;
+  href?: string;
+  countBadge?: number;
+};
+
+const ICONS: Record<EntityLabel, any> = {
+  Person: User,
+  Organization: Building2,
+  Location: MapPin,
+  Email: AtSign,
+  Domain: Globe,
+  IP: Network,
+  Misc: Tag,
+};
+
+export default function EntityBadge({
+  label,
+  value,
+  size = 'md',
+  clickable = false,
+  onClick,
+  href,
+  countBadge,
+}: Props) {
+  const className = `inline-flex items-center gap-1 px-2 py-1 rounded-2xl font-medium ${ENTITY_COLORS[label]} ${
+    clickable ? 'cursor-pointer focus:ring-2 ring-offset-2' : ''
+  } ${size === 'sm' ? 'text-xs' : 'text-sm'}`;
+  const content = (
+    <span className={className} aria-label={value ? `Filter Suche nach Wert ${value}` : `Filter Suche nach ${label}`}> 
+      {(() => {
+        const Icon = ICONS[label];
+        return <Icon size={14} />;
+      })()}
+      {value ? `${label}: ${value}` : label}
+      {countBadge !== undefined && (
+        <span className="ml-1 rounded-full bg-white px-1 text-xs text-black">{countBadge}</span>
+      )}
+    </span>
+  );
+  if (href) {
+    return (
+      <Link href={href} passHref legacyBehavior>
+        <a>{content}</a>
+      </Link>
+    );
+  }
+  return (
+    <button type="button" role="button" aria-pressed="false" onClick={onClick} className="bg-transparent">
+      {content}
+    </button>
+  );
+}
+

--- a/apps/frontend/src/components/entities/EntityBadgeList.tsx
+++ b/apps/frontend/src/components/entities/EntityBadgeList.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import EntityBadge from './EntityBadge';
+import { EntityLabel } from '../../lib/entities';
+
+export type BadgeItem = {
+  label: EntityLabel;
+  value?: string;
+  count?: number;
+  nodeId?: string;
+};
+
+type Props = {
+  items: BadgeItem[];
+  onBadgeClick?: (item: BadgeItem) => void;
+  collapseAfter?: number;
+};
+
+export default function EntityBadgeList({ items, onBadgeClick, collapseAfter = 12 }: Props) {
+  const deduped = useMemo(() => {
+    const map = new Map<string, BadgeItem>();
+    for (const it of items) {
+      const key = `${it.label}:${(it.value || '').toLowerCase()}`;
+      const existing = map.get(key);
+      if (existing) existing.count = (existing.count || 1) + (it.count || 1);
+      else map.set(key, { ...it, count: it.count || 1 });
+    }
+    return Array.from(map.values()).sort((a, b) => {
+      if (a.label === b.label) return (a.value || '').localeCompare(b.value || '');
+      return a.label.localeCompare(b.label);
+    });
+  }, [items]);
+
+  const shown = deduped.slice(0, collapseAfter);
+  const hidden = deduped.slice(collapseAfter);
+
+  const renderBadge = (item: BadgeItem, i: number) => (
+    <EntityBadge
+      key={i}
+      label={item.label}
+      value={item.value}
+      clickable={!!onBadgeClick}
+      countBadge={item.count}
+      onClick={() => onBadgeClick?.(item)}
+    />
+  );
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {shown.map(renderBadge)}
+      {hidden.length > 0 && (
+        <details>
+          <summary className="cursor-pointer">+{hidden.length} mehr</summary>
+          <div className="flex flex-wrap gap-1 mt-1">{hidden.map(renderBadge)}</div>
+        </details>
+      )}
+    </div>
+  );
+}
+

--- a/apps/frontend/src/components/search/FilterChips.tsx
+++ b/apps/frontend/src/components/search/FilterChips.tsx
@@ -1,23 +1,57 @@
 interface Props {
   filters: Record<string, string[]>;
+  entity?: string[];
+  value?: string[];
   onRemove: (facet: string, value: string) => void;
+  onRemoveEntity?: (label: string) => void;
+  onRemoveValue?: (v: string) => void;
   onClearAll: () => void;
 }
 
-export default function FilterChips({ filters, onRemove, onClearAll }: Props) {
-  const entries = Object.entries(filters).flatMap(([facet, values]) =>
-    values.map((v) => ({ facet, value: v })),
-  );
+export default function FilterChips({
+  filters,
+  entity,
+  value,
+  onRemove,
+  onRemoveEntity,
+  onRemoveValue,
+  onClearAll,
+}: Props) {
+  const entries: { type: 'facet' | 'entity' | 'value'; facet?: string; value: string }[] = [
+    ...Object.entries(filters).flatMap(([facet, values]) =>
+      values.map((v) => ({ type: 'facet' as const, facet, value: v })),
+    ),
+    ...(entity || []).map((v) => ({ type: 'entity' as const, value: v })),
+    ...(value || []).map((v) => ({ type: 'value' as const, value: v })),
+  ];
   if (entries.length === 0) return null;
 
   return (
     <div>
-      {entries.map(({ facet, value }) => (
-        <span key={`${facet}:${value}`}>
-          {facet}: {value}{' '}
-          <button onClick={() => onRemove(facet, value)}>x</button>
-        </span>
-      ))}
+      {entries.map((e) => {
+        if (e.type === 'entity') {
+          return (
+            <span key={`entity:${e.value}`}>
+              entity: {e.value}{' '}
+              <button onClick={() => onRemoveEntity?.(e.value)}>x</button>
+            </span>
+          );
+        }
+        if (e.type === 'value') {
+          return (
+            <span key={`value:${e.value}`}>
+              value: {e.value}{' '}
+              <button onClick={() => onRemoveValue?.(e.value)}>x</button>
+            </span>
+          );
+        }
+        return (
+          <span key={`${e.facet}:${e.value}`}>
+            {e.facet}: {e.value}{' '}
+            <button onClick={() => onRemove(e.facet!, e.value)}>x</button>
+          </span>
+        );
+      })}
       <button onClick={onClearAll}>Clear all</button>
     </div>
   );

--- a/apps/frontend/src/components/search/ResultItem.tsx
+++ b/apps/frontend/src/components/search/ResultItem.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import type { SearchHit } from '../../types/search';
+import EntityBadge from '../entities/EntityBadge';
+import { displayValue, normalizeLabel } from '../../lib/entities';
+import { buildSearchUrl } from '../../lib/searchNav';
 
 interface Props {
   hit: SearchHit;
@@ -16,6 +20,8 @@ function Highlights({ hit }: { hit: SearchHit }) {
 }
 
 export default function ResultItem({ hit }: Props) {
+  const router = useRouter();
+  const query = router.query;
   return (
     <article>
       {hit.id ? (
@@ -26,10 +32,20 @@ export default function ResultItem({ hit }: Props) {
         <h3>{hit.title || hit.id}</h3>
       )}
       <Highlights hit={hit} />
-      <div>
-        {hit.entity_types?.map((t) => (
-          <span key={t}>{t} </span>
-        ))}
+      <div className="flex flex-wrap gap-1">
+        {hit.entity_types?.map((t) => {
+          const label = normalizeLabel(t);
+          const href = buildSearchUrl(query, { addEntity: label });
+          return <EntityBadge key={t} label={label} href={href} clickable />;
+        })}
+        {hit.meta?.entities?.map((e: any, idx: number) => {
+          const label = normalizeLabel(e.label);
+          const value = displayValue(e.value || e.text);
+          const href = buildSearchUrl(query, { addValue: value });
+          return (
+            <EntityBadge key={idx} label={label} value={value} href={href} clickable />
+          );
+        })}
         {hit.source && <span>{hit.source} </span>}
         {hit.node_id && (
           <Link href={`/graphx?focus=${hit.node_id}`}>Graph</Link>

--- a/apps/frontend/src/hooks/useSearch.ts
+++ b/apps/frontend/src/hooks/useSearch.ts
@@ -5,6 +5,7 @@ export interface UseSearchInput {
   q?: string;
   filters?: Record<string, string[]>;
   entity?: string[];
+  value?: string[];
   sort?: string;
   rerank?: boolean;
   page?: number;
@@ -31,6 +32,7 @@ export function useSearch(params: UseSearchInput) {
         query.set('limit', String(pageSize));
         query.set('offset', String((page - 1) * pageSize));
         if (params.entity) params.entity.forEach((e) => query.append('entity_type', e));
+        if (params.value) params.value.forEach((v) => query.append('value', v));
         if (params.filters && Object.keys(params.filters).length) {
           query.set('filters', JSON.stringify(params.filters));
         }
@@ -55,7 +57,8 @@ export function useSearch(params: UseSearchInput) {
     params.page,
     params.pageSize,
     JSON.stringify(params.filters),
-    params.entity?.join(',')
+    params.entity?.join(','),
+    params.value?.join(',')
   ]);
 
   return { data, loading, error };

--- a/apps/frontend/src/lib/entities.ts
+++ b/apps/frontend/src/lib/entities.ts
@@ -1,0 +1,85 @@
+export type EntityLabel =
+  | 'Person'
+  | 'Organization'
+  | 'Location'
+  | 'Email'
+  | 'Domain'
+  | 'IP'
+  | 'Misc';
+
+export const ENTITY_COLORS: Record<EntityLabel, string> = {
+  Person: 'bg-blue-100 text-blue-800',
+  Organization: 'bg-purple-100 text-purple-800',
+  Location: 'bg-emerald-100 text-emerald-800',
+  Email: 'bg-amber-100 text-amber-800',
+  Domain: 'bg-indigo-100 text-indigo-800',
+  IP: 'bg-rose-100 text-rose-800',
+  Misc: 'bg-slate-100 text-slate-800',
+};
+
+/** Normalize various NER labels into the set of supported EntityLabel values. */
+export function normalizeLabel(x: string): EntityLabel {
+  const s = x.trim().toLowerCase();
+  switch (s) {
+    case 'per':
+    case 'pers':
+    case 'person':
+    case 'human':
+      return 'Person';
+    case 'org':
+    case 'organization':
+    case 'organisation':
+    case 'company':
+    case 'corporation':
+      return 'Organization';
+    case 'loc':
+    case 'location':
+    case 'place':
+    case 'geo':
+      return 'Location';
+    case 'email':
+    case 'e-mail':
+    case 'mail':
+      return 'Email';
+    case 'domain':
+    case 'url':
+    case 'hostname':
+    case 'site':
+      return 'Domain';
+    case 'ip':
+    case 'ipv4':
+    case 'ipv6':
+    case 'ipaddress':
+      return 'IP';
+    default:
+      return 'Misc';
+  }
+}
+
+export function displayValue(v: string): string {
+  return (v || '').trim();
+}
+
+/**
+ * Deduplicate a list of entities by normalised label and case-insensitive value.
+ * Returns a sorted array (by label then value) including a count for each entry.
+ */
+export function uniqueEntities(
+  ents: { label: string; value: string }[],
+): { label: EntityLabel; value: string; count: number }[] {
+  const map = new Map<string, { label: EntityLabel; value: string; count: number }>();
+  for (const e of ents) {
+    const label = normalizeLabel(e.label);
+    const value = displayValue(e.value);
+    if (!value) continue;
+    const key = `${label}:${value.toLowerCase()}`;
+    const existing = map.get(key);
+    if (existing) existing.count += 1;
+    else map.set(key, { label, value, count: 1 });
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    if (a.label === b.label) return a.value.localeCompare(b.value);
+    return a.label.localeCompare(b.label);
+  });
+}
+

--- a/apps/frontend/src/lib/searchNav.ts
+++ b/apps/frontend/src/lib/searchNav.ts
@@ -1,0 +1,47 @@
+import { ParsedUrlQuery } from 'querystring';
+import { EntityLabel } from './entities';
+
+export function buildSearchUrl(
+  currentQuery: ParsedUrlQuery,
+  opts: {
+    addEntity?: EntityLabel;
+    addValue?: string;
+    remove?: { entity?: EntityLabel; value?: string };
+  },
+): string {
+  const q: Record<string, any> = { ...currentQuery };
+  const arr = (key: string) => {
+    const v = q[key];
+    return Array.isArray(v) ? [...v] : v ? [v] : [];
+  };
+  if (opts.addEntity) {
+    const list = arr('entity');
+    if (!list.includes(opts.addEntity)) list.push(opts.addEntity);
+    q.entity = list;
+    delete q.page;
+  }
+  if (opts.addValue) {
+    const list = arr('value');
+    if (!list.includes(opts.addValue)) list.push(opts.addValue);
+    q.value = list;
+    delete q.page;
+  }
+  if (opts.remove?.entity) {
+    const list = arr('entity').filter((e) => e !== opts.remove?.entity);
+    if (list.length) q.entity = list;
+    else delete q.entity;
+  }
+  if (opts.remove?.value) {
+    const list = arr('value').filter((v) => v !== opts.remove?.value);
+    if (list.length) q.value = list;
+    else delete q.value;
+  }
+  const search = new URLSearchParams();
+  Object.entries(q).forEach(([k, v]) => {
+    if (v === undefined) return;
+    if (Array.isArray(v)) v.forEach((val) => search.append(k, String(val)));
+    else search.set(k, String(v));
+  });
+  return `/search?${search.toString()}`;
+}
+


### PR DESCRIPTION
## Summary
- add entity utilities and colors
- implement reusable EntityBadge and list
- enable search and document pages with clickable entity filters

## Testing
- `npx vitest run src/__tests__/entities.spec.ts src/__tests__/EntityBadge.spec.tsx src/__tests__/search-quickfilters.spec.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b80ab702e48324ba8a29640ccd42be