### PR TITLE
Fix gitleaks CI workflow output and permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,11 +7,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install gitleaks
+      - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: detect --source . --redact --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif
+          args: --source . --redact --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif
       - name: Upload SARIF to code scanning
+        if: ${{ github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: gitleaks.sarif


### PR DESCRIPTION
## Summary
- ensure gitleaks action writes SARIF report and has token
- skip SARIF upload on pull_request events to avoid permission error

## Testing
- `gitleaks detect --source . --redact --config .gitleaks.toml --report-format sarif --report-path gitleaks.sarif`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b8150852008324a832c3625e9cca1b