### PR TITLE
chore(dev): unify Neo4j env to NEO4J_PASS, silence OTEL in dev, add /healthz to entity-resolution

### DIFF
--- a/services/doc-entities/dev_run.sh
+++ b/services/doc-entities/dev_run.sh
@@ -2,17 +2,15 @@
 set -a
 [ -f ./.env.local ] && . ./.env.local
 set +a
-export OTEL_SDK_DISABLED=1
-export OTEL_TRACES_EXPORTER=none
-export OTEL_METRICS_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-cd "$(dirname "$0")"
-. .venv/bin/activate
-exec uvicorn app:app --host 127.0.0.1 --port 8406 --reload
 export OTEL_SDK_DISABLED=true
 export OTEL_TRACES_EXPORTER=none
 export OTEL_METRICS_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=*
+export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="*"
 unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+cd "$(dirname "$0")"
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
+. .venv/bin/activate
+exec uvicorn app:app --host 127.0.0.1 --port 8406 --reload

--- a/services/doc-entities/obs/otel_boot.py
+++ b/services/doc-entities/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "doc-entities")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "doc-entities")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/entity-resolution/app.py
+++ b/services/entity-resolution/app.py
@@ -14,6 +14,10 @@ app = FastAPI(title="Entity Resolution v0")
 FastAPIInstrumentor().instrument_app(app)
 app.mount("/metrics", make_asgi_app())
 
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
 class MatchReq(BaseModel):
     query: str
     candidates: List[str]

--- a/services/entity-resolution/dev_run.sh
+++ b/services/entity-resolution/dev_run.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-export OTEL_SDK_DISABLED=1
-export OTEL_TRACES_EXPORTER=none
-export OTEL_METRICS_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-cd "$(dirname "$0")"
-. .venv/bin/activate
-exec uvicorn app:app --host 127.0.0.1 --port 8404 --reload
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
 export OTEL_SDK_DISABLED=true
 export OTEL_TRACES_EXPORTER=none
 export OTEL_METRICS_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=*
+export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="*"
 unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+cd "$(dirname "$0")"
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
+. .venv/bin/activate
+exec uvicorn app:app --host 127.0.0.1 --port 8404 --reload

--- a/services/entity-resolution/obs/otel_boot.py
+++ b/services/entity-resolution/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "entity-resolution")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "entity-resolution")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/entity-resolution/tests/conftest.py
+++ b/services/entity-resolution/tests/conftest.py
@@ -1,26 +1,19 @@
-import os, pathlib, pytest, importlib.util, sys
+import os, pathlib, pytest, importlib.util
 from httpx import AsyncClient, ASGITransport
 
 os.environ.setdefault("OTEL_SDK_DISABLED", "true")
 MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "app.py"
-spec = importlib.util.spec_from_file_location("graph_api_app", MODULE_PATH)
+spec = importlib.util.spec_from_file_location("er_app", MODULE_PATH)
 app_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(app_module)
-sys.modules.setdefault("app", app_module)
 app = app_module.app
 
 @pytest.fixture(scope="session")
 def anyio_backend():
     return "asyncio"
 
-@pytest.fixture(scope="session")
-def test_settings():
-    os.environ["ALLOW_TEST_MODE"] = "1"
-    yield
-    os.environ.pop("ALLOW_TEST_MODE", None)
-
 @pytest.fixture
-async def client(test_settings):
+async def client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/services/entity-resolution/tests/test_healthz.py
+++ b/services/entity-resolution/tests/test_healthz.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.mark.anyio
+async def test_health(client):
+    r = await client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json().get("status") == "ok"

--- a/services/graph-api/.env.local
+++ b/services/graph-api/.env.local
@@ -1,0 +1,3 @@
+NEO4J_URI=bolt://127.0.0.1:7687
+NEO4J_USER=neo4j
+NEO4J_PASS=neo4jpass

--- a/services/graph-api/app.py
+++ b/services/graph-api/app.py
@@ -26,10 +26,10 @@ from neo4j import GraphDatabase
 from auth import user_from_token
 from opa import allow
 
-NEO4J_URI = os.getenv("NEO4J_URI","bolt://127.0.0.1:7687")
-NEO4J_USER = os.getenv("NEO4J_USER","neo4j")
-NEO4J_PASS = os.getenv("NEO4J_PASS") or os.getenv("NEO4J_PASSWORD","neo4jpass")
-REQUIRE_AUTH = os.getenv("REQUIRE_AUTH","0") == "1"
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://127.0.0.1:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", os.getenv("NEO4J_USERNAME", "neo4j"))
+NEO4J_PASS = os.getenv("NEO4J_PASS") or os.getenv("NEO4J_PASSWORD", "neo4jpass")
+REQUIRE_AUTH = os.getenv("REQUIRE_AUTH", "0") == "1"
 
 driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASS))
 

--- a/services/graph-api/dev_run.sh
+++ b/services/graph-api/dev_run.sh
@@ -2,22 +2,17 @@
 set -a
 [ -f ./.env.local ] && . ./.env.local
 set +a
-export OTEL_SDK_DISABLED=1
+export OTEL_SDK_DISABLED=true
 export OTEL_TRACES_EXPORTER=none
 export OTEL_METRICS_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
+export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="*"
 unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 cd "$(dirname "$0")"
 set -a
 [ -f ./.env.local ] && . ./.env.local
 set +a
 echo "[graph-api] Using Neo4j ENV:"
-env | grep -E "^(NEO4J|BOLT|GRAPH)_" | sed -E "s/(NEO4J_PASSWORD=).*/\1****/; s/(NEO4J_AUTH=neo4j\/).*/\1****/"
+env | grep -E "^(NEO4J|BOLT|GRAPH)_" | sed -E "s/(NEO4J_(PASS|PASSWORD)=).*/\1****/; s/(NEO4J_AUTH=neo4j\/).*/\1****/"
 . .venv/bin/activate
 exec uvicorn app:app --host 127.0.0.1 --port 8402 --reload
-export OTEL_SDK_DISABLED=true
-export OTEL_TRACES_EXPORTER=none
-export OTEL_METRICS_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=*
-unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT

--- a/services/graph-api/obs/otel_boot.py
+++ b/services/graph-api/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "graph-api")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "graph-api")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/graph-views/dev_run.sh
+++ b/services/graph-views/dev_run.sh
@@ -2,17 +2,15 @@
 set -a
 [ -f ./.env.local ] && . ./.env.local
 set +a
-export OTEL_SDK_DISABLED=1
-export OTEL_TRACES_EXPORTER=none
-export OTEL_METRICS_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-cd "$(dirname "$0")"
-. .venv/bin/activate
-exec uvicorn app:app --host 127.0.0.1 --port 8403 --reload
 export OTEL_SDK_DISABLED=true
 export OTEL_TRACES_EXPORTER=none
 export OTEL_METRICS_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=*
+export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="*"
 unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+cd "$(dirname "$0")"
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
+. .venv/bin/activate
+exec uvicorn app:app --host 127.0.0.1 --port 8403 --reload

--- a/services/graph-views/obs/otel_boot.py
+++ b/services/graph-views/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "graph-views")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "graph-views")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/opa-audit-sink/obs/otel_boot.py
+++ b/services/opa-audit-sink/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "opa-audit-sink")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "opa-audit-sink")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/search-api/dev_run.sh
+++ b/services/search-api/dev_run.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-export OTEL_SDK_DISABLED=1
-export OTEL_TRACES_EXPORTER=none
-export OTEL_METRICS_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-cd "$(dirname "$0")"
-. .venv/bin/activate
-exec uvicorn app:app --host 127.0.0.1 --port 8401 --reload
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
 export OTEL_SDK_DISABLED=true
 export OTEL_TRACES_EXPORTER=none
 export OTEL_METRICS_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=*
+export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="*"
 unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+cd "$(dirname "$0")"
+set -a
+[ -f ./.env.local ] && . ./.env.local
+set +a
+. .venv/bin/activate
+exec uvicorn app:app --host 127.0.0.1 --port 8401 --reload

--- a/services/search-api/obs/otel_boot.py
+++ b/services/search-api/obs/otel_boot.py
@@ -1,20 +1,24 @@
 
 import os
-from opentelemetry import trace, metrics
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-service_name = os.getenv("OTEL_SERVICE_NAME", "search-api")
-otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
+if os.getenv("OTEL_SDK_DISABLED", "").lower() in {"1", "true", "yes"}:
+    pass
+else:
+    from opentelemetry import trace, metrics
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 
-resource = Resource.create({"service.name": service_name})
-tp = TracerProvider(resource=resource)
-tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
-trace.set_tracer_provider(tp)
+    service_name = os.getenv("OTEL_SERVICE_NAME", "search-api")
+    otel_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.default.svc:4317")
 
-metrics.set_meter_provider(MeterProvider(resource=resource))
-# Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push
+    resource = Resource.create({"service.name": service_name})
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=otel_endpoint, insecure=True)))
+    trace.set_tracer_provider(tp)
+
+    metrics.set_meter_provider(MeterProvider(resource=resource))
+    # Optional: metrics via OTLP – many collectors prefer pull; keep SDK for future push

--- a/services/search-api/tests/conftest.py
+++ b/services/search-api/tests/conftest.py
@@ -1,8 +1,12 @@
-import os, pathlib, sys, pytest
+import os, pathlib, pytest, sys, importlib
 from httpx import AsyncClient, ASGITransport
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from app.main import app  # import FastAPI app
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
+SERVICE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVICE_DIR))
+import app.main as app_main  # type: ignore
+sys.modules.setdefault("app.main", app_main)
+app = app_main.app
 
 @pytest.fixture(scope="session")
 def anyio_backend():


### PR DESCRIPTION
## Summary
- standardize Neo4j credentials on `NEO4J_PASS` with legacy fallback
- disable OpenTelemetry exporters in dev scripts and skip boot when `OTEL_SDK_DISABLED`
- expose `/healthz` on entity-resolution and add test

## Testing
- `pytest services/entity-resolution/tests`
- `pytest services/graph-api/tests`
- `pytest services/search-api/tests`
- `pytest services/nlp-service/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b850c2c8f88324b1f2aff96e07beeb