### PR TITLE
Add dev setup checklist and expand TODO index

### DIFF
--- a/Checkliste.md
+++ b/Checkliste.md
@@ -1,0 +1,25 @@
+# ✅ Dev Setup Checkliste
+
+Kurzanleitung für ein lokales End-to-End Setup von InfoTerminal (MVP).
+
+## Schritte
+
+1. **Services starten**
+   - `make dev-up`
+     - Startet OpenSearch, Neo4j, Postgres, Backend-Services und Frontend.
+   - Optional separat: `services/nlp-service/dev_run.sh`
+
+2. **Healthchecks prüfen**
+   - `scripts/dev_health.sh`
+
+3. **Seed-Daten laden**
+   - `make seed-graph`
+   - `make seed-demo` *(PDFs → Aleph, CSV → Postgres)*
+
+4. **Policies testen**
+   - `make opa-test`
+
+5. **Optional: dbt Modelle ausführen**
+   - `make dbt-all`
+
+Weitere Details siehe `TODO-Index.md`.

--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -34,6 +34,9 @@ Ziel: Erste veröffentlichbare Version (MVP), die Datenintegration, Suche, Graph
   - [ ] Mini-Beispiel (z. B. täglicher CSV-Import in Postgres)
 - [ ] dbt Modelle:
   - [ ] 1 Beispiel-Transformation (CSV → Postgres Table)
+- [ ] Demo-Daten Seeds
+  - [x] Graph (services/graph-api/scripts/seed_graph.py)
+  - [ ] PDFs/CSV (scripts/seed_demo.sh)
 
 ---
 
@@ -53,6 +56,7 @@ Ziel: Erste veröffentlichbare Version (MVP), die Datenintegration, Suche, Graph
 - [ ] Superset:
   - [ ] Beispiel-Dashboard (Entity Counts, Dokumente pro Kategorie)
   - [ ] OIDC-Login aktivieren (Keycloak)
+  - [ ] dbt Dataset Sync (`infra/analytics/superset_dbt_sync.py`)
 - [ ] Grafana:
   - [ ] Mini-Dashboard (API Latency, Request Count)
 
@@ -79,12 +83,20 @@ Ziel: Erste veröffentlichbare Version (MVP), die Datenintegration, Suche, Graph
 ## 6. Security & Governance (Dev-Modus)
 
 - [ ] Keycloak Realm + Clients für InfoTerminal
+  - [ ] Automatisierter Import via `infra/auth/keycloak_import.sh`
 - [x] OPA ForwardAuth Beispiel-Policy
 - [ ] Basic Audit-Log für Plugin-Runs
 
 ---
 
-## 7. Doku
+## 7. Observability
+
+- [ ] Otel Collector + Prometheus + Grafana + Loki scaffold
+- [ ] /metrics Endpunkte der Services prüfen
+
+---
+
+## 8. Doku
 
 - [ ] **Quickstart (Compose)**
   - [ ] Install prerequisites
@@ -109,7 +121,7 @@ Ziel: Erste veröffentlichbare Version (MVP), die Datenintegration, Suche, Graph
 
 ---
 
-## 8. Release Management
+## 9. Release Management
 
 - [ ] Version `v0.1.0` taggen
 - [ ] GitHub Release mit:


### PR DESCRIPTION
## Summary
- document end-to-end dev steps in new `Checkliste.md`
- track seed scripts, Superset sync, Keycloak import, and observability in TODO index

## Testing
- `npm test` *(fails: expected 'w-3 h-3 rounded-full undefined' to contain 'bg-green-500')*
- `pytest -q services/graph-api/tests` *(fails: ModuleNotFoundError: No module named 'auth')*
- `pytest -q services/search-api/tests`
- `pytest -q services/doc-entities/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b86d03cf8c8324b972c7305905e422