### PR TITLE
Handle Neo4j auth backoff and optional graph-views start

### DIFF
--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -1,16 +1,9 @@
-export const SEARCH_API = process.env.NEXT_PUBLIC_SEARCH_API || '';
-if (!SEARCH_API) console.warn('NEXT_PUBLIC_SEARCH_API is not set');
+export const config = {
+  SEARCH_API: process.env.NEXT_PUBLIC_SEARCH_API ?? "http://localhost:8611",
+  GRAPH_API:  process.env.NEXT_PUBLIC_GRAPH_API  ?? "http://localhost:8612",
+  DOCENTITIES_API: process.env.NEXT_PUBLIC_DOCENTITIES_API ?? "http://localhost:8613",
+  NLP_API:    process.env.NEXT_PUBLIC_NLP_API    ?? "http://localhost:8404",
+  VIEWS_API:  process.env.NEXT_PUBLIC_VIEWS_API  ?? "http://localhost:8403"
+} as const;
 
-export const GRAPH_API = process.env.NEXT_PUBLIC_GRAPH_API || '';
-if (!GRAPH_API) console.warn('NEXT_PUBLIC_GRAPH_API is not set');
-
-export const DOCENTITIES_API = process.env.NEXT_PUBLIC_DOCENTITIES_API || '';
-if (!DOCENTITIES_API) console.warn('NEXT_PUBLIC_DOCENTITIES_API is not set');
-
-export const NLP_API = process.env.NEXT_PUBLIC_NLP_API || '';
-if (!NLP_API) console.warn('NEXT_PUBLIC_NLP_API is not set');
-
-export const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || '';
-
-export const SEARCH_FILTER_MODE =
-  process.env.NEXT_PUBLIC_SEARCH_FILTER_MODE || 'quote_query';
+export const GRAFANA_URL = process.env.NEXT_PUBLIC_GRAFANA_URL || "";

--- a/apps/frontend/pages/api/health.ts
+++ b/apps/frontend/pages/api/health.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { SEARCH_API, GRAPH_API, DOCENTITIES_API, NLP_API } from '../../lib/config';
+import { config } from '../../lib/config';
 
 type ServiceState = 'ok' | 'degraded' | 'down' | 'unreachable';
 export type HealthResponse = {
@@ -36,10 +36,10 @@ async function ping(url: string): Promise<{ state: ServiceState; latencyMs: numb
 
 export async function getHealth(): Promise<HealthResponse> {
   const services = await Promise.all([
-    ping(SEARCH_API),
-    ping(GRAPH_API),
-    ping(DOCENTITIES_API),
-    ping(NLP_API),
+    ping(config.SEARCH_API),
+    ping(config.GRAPH_API),
+    ping(config.DOCENTITIES_API),
+    ping(config.NLP_API),
   ]);
   return {
     timestamp: new Date().toISOString(),

--- a/apps/frontend/pages/graphx.tsx
+++ b/apps/frontend/pages/graphx.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import CytoscapeComponent from "react-cytoscapejs"
-import config from '../lib/config'
+import { config } from '../lib/config'
 
 type Edge = { from: any; to: any; rel: string }
 type Elem = { data: any; position?: any; locked?: boolean }
@@ -12,6 +12,9 @@ const STORAGE_KEY = "infoterminal.graph.view"
 // Use configuration instead of hardcoded URLs
 const GRAPH_API = config.GRAPH_API
 const VIEWS_API = config.VIEWS_API
+if (!GRAPH_API) {
+  console.warn("GRAPH_API missing; falling back to http://localhost:8612")
+}
 
 // Mock data for when APIs are not available
 const MOCK_EDGES: Edge[] = [

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -101,19 +101,19 @@ body {
 }
 
 .heading-xl {
-  @apply text-3xl lg:text-4xl heading;
+  @apply text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100;
 }
 
 .heading-lg {
-  @apply text-2xl lg:text-3xl heading;
+  @apply text-2xl lg:text-3xl font-bold text-gray-900 dark:text-gray-100;
 }
 
 .heading-md {
-  @apply text-xl lg:text-2xl heading;
+  @apply text-xl lg:text-2xl font-bold text-gray-900 dark:text-gray-100;
 }
 
 .heading-sm {
-  @apply text-lg heading;
+  @apply text-lg font-bold text-gray-900 dark:text-gray-100;
 }
 
 .text-muted {

--- a/scripts/dev_up.sh
+++ b/scripts/dev_up.sh
@@ -96,7 +96,7 @@ if [ "$DEV_LOCAL" = "1" ]; then
     log "Starting graph-views (local, PG env)"
     (
       cd services/graph-views
-      PG_HOST=127.0.0.1 PG_PORT=5432 PG_DB=it_graph PG_USER=it_user PG_PASSWORD=it_pass \
+      PG_HOST=127.0.0.1 PG_PORT=55432 PG_DB=it_graph PG_USER=it_user PG_PASSWORD=it_pass \
       bash dev_run.sh
     ) > /tmp/it_graph-views.log 2>&1 &
   fi

--- a/services/graph-api/utils/neo4j_client.py
+++ b/services/graph-api/utils/neo4j_client.py
@@ -1,0 +1,34 @@
+import time
+from typing import Optional
+from neo4j import GraphDatabase, exceptions
+
+def get_driver(uri: str, user: str, password: str, max_attempts: int = 10, base_delay: float = 1.0):
+    """
+    Erstellt einen Neo4j-Driver mit Backoff.
+    - Handhabt explizit AuthenticationRateLimit, ohne den Dienst sofort zu beenden.
+    """
+    delay = base_delay
+    last_err: Optional[Exception] = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            driver = GraphDatabase.driver(uri, auth=(user, password))
+            # Sanity check
+            with driver.session() as s:
+                s.run("RETURN 1").consume()
+            return driver
+        except exceptions.AuthError as e:
+            msg = str(e)
+            code = getattr(e, "code", "")
+            if "AuthenticationRateLimit" in msg or code.endswith("AuthenticationRateLimit"):
+                last_err = e
+                time.sleep(delay)
+                delay = min(delay * 2, 30)  # Exponential Backoff capped
+                continue
+            # Andere Auth-Fehler sofort durchreichen
+            raise
+        except Exception as e:
+            last_err = e
+            time.sleep(min(delay, 5))
+            delay = min(delay * 2, 30)
+    # Nach max_attempts sauber fehlschlagen
+    raise RuntimeError(f"Neo4j connection failed after {max_attempts} attempts: {last_err}")

--- a/services/graph-views/dev_run.sh
+++ b/services/graph-views/dev_run.sh
@@ -8,5 +8,27 @@ unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 cd "$(dirname "$0")"
 set -a; [ -f ./.env.local ] && . ./.env.local; set +a
 . .venv/bin/activate 2>/dev/null || true
-exec uvicorn app:app --host 127.0.0.1 --port 8403 --reload
+
+PORT="${PORT:-8403}"
+HOST="${HOST:-127.0.0.1}"
+PG_HOST="${PG_HOST:-127.0.0.1}"
+PG_PORT="${PG_PORT:-55432}"
+PG_DB="${PG_DB:-it_graph}"
+PG_USER="${PG_USER:-it_user}"
+PG_PASSWORD="${PG_PASSWORD:-it_pass}"
+
+echo "[graph-views] waiting for postgres ${PG_HOST}:${PG_PORT} ..."
+for i in {1..60}; do
+  (echo >/dev/tcp/${PG_HOST}/${PG_PORT}) >/dev/null 2>&1 && ok=1 || ok=0
+  [ "$ok" = 1 ] && break
+  sleep 1
+done
+if [ "${ok:-0}" != "1" ]; then
+  echo "[graph-views] postgres not reachable, skipping start."
+  exit 0
+fi
+
+export PG_HOST PG_PORT PG_DB PG_USER PG_PASSWORD
+echo "[graph-views] starting on http://${HOST}:${PORT}"
+exec uvicorn app:app --host "$HOST" --port "$PORT" --reload
 


### PR DESCRIPTION
## Summary
- add Neo4j driver helper with authentication rate-limit backoff
- skip graph-views start when Postgres unreachable and align PG port
- centralize frontend API config and drop invalid Tailwind `heading` utility

## Testing
- `pytest services/graph-api/tests services/graph-views/tests` *(fails: Neo4j connection refused)*
- `npm test` (in `apps/frontend`) *(fails: GlobalHealth.spec.tsx assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d8e04e54832494ac3bd38f15523c