### PR TITLE
Improve Neo4j backoff and Tailwind config

### DIFF
--- a/apps/frontend/pages/graphx.tsx
+++ b/apps/frontend/pages/graphx.tsx
@@ -263,7 +263,7 @@ export default function GraphX() {
 
   return (
     <main style={{ maxWidth: 1200, margin: "30px auto", fontFamily: "ui-sans-serif" }}>
-      <h1>Graph Viewer (expand / pin / save)</h1>
+      <h1 className="text-2xl font-semibold">Graph Viewer (expand / pin / save)</h1>
       
       {error && (
         <div style={{ 

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,7 +1,23 @@
+const colors = require('tailwindcss/colors')
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  // TODO: weitere Theme/Plugin-Anpassungen bei Bedarf
-};
+  theme: {
+    extend: {
+      colors: {
+        primary: colors.blue,
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+  ],
+}

--- a/services/graph-api/app.py
+++ b/services/graph-api/app.py
@@ -44,6 +44,11 @@ instrumentator = Instrumentator().instrument(app)
 @app.on_event("startup")
 async def _startup() -> None:
     instrumentator.expose(app, include_in_schema=False, should_gzip=True)
+
+
+@app.on_event("shutdown")
+def _shutdown() -> None:
+    driver.close()
 app.add_middleware(
   CORSMiddleware,
   allow_origins=["http://localhost:3000","http://127.0.0.1:3000"],

--- a/services/graph-api/utils/neo4j_client.py
+++ b/services/graph-api/utils/neo4j_client.py
@@ -4,31 +4,26 @@ from neo4j import GraphDatabase, exceptions
 
 def get_driver(uri: str, user: str, password: str, max_attempts: int = 10, base_delay: float = 1.0):
     """
-    Erstellt einen Neo4j-Driver mit Backoff.
-    - Handhabt explizit AuthenticationRateLimit, ohne den Dienst sofort zu beenden.
+    Erstellt einen Neo4j-Driver mit Backoff; fängt gezielt AuthenticationRateLimit ab.
     """
     delay = base_delay
     last_err: Optional[Exception] = None
     for attempt in range(1, max_attempts + 1):
         try:
             driver = GraphDatabase.driver(uri, auth=(user, password))
-            # Sanity check
             with driver.session() as s:
                 s.run("RETURN 1").consume()
             return driver
         except exceptions.AuthError as e:
-            msg = str(e)
-            code = getattr(e, "code", "")
-            if "AuthenticationRateLimit" in msg or code.endswith("AuthenticationRateLimit"):
+            code = getattr(e, "code", "") or ""
+            if "AuthenticationRateLimit" in str(e) or code.endswith("AuthenticationRateLimit"):
                 last_err = e
                 time.sleep(delay)
-                delay = min(delay * 2, 30)  # Exponential Backoff capped
+                delay = min(delay * 2, 30.0)
                 continue
-            # Andere Auth-Fehler sofort durchreichen
             raise
         except Exception as e:
             last_err = e
-            time.sleep(min(delay, 5))
-            delay = min(delay * 2, 30)
-    # Nach max_attempts sauber fehlschlagen
-    raise RuntimeError(f"Neo4j connection failed after {max_attempts} attempts: {last_err}")
+            time.sleep(min(delay, 5.0))
+            delay = min(delay * 2, 30.0)
+    raise RuntimeError(f"Neo4j connect failed after {max_attempts} attempts: {last_err}")


### PR DESCRIPTION
## Summary
- handle Neo4j authentication rate limits with exponential backoff and close driver on shutdown
- add Tailwind primary color setup and replace legacy heading with utility classes

## Testing
- `pytest services/graph-api/tests services/graph-views/tests` *(fails: Neo4j connect failed)*
- `npm test` *(fails: expected 'w-3 h-3 rounded-full undefined' to contain 'bg-green-500')*

------
https://chatgpt.com/codex/tasks/task_e_68b8dc3c2afc832481e5e1799ee2b1ab