### PR TITLE
feat(cli): print banner and add version option

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -12,7 +12,13 @@ pip install -e .
 
 ```bash
 it --help
+
+# show version
+it -V
 ```
+
+The CLI prints a banner on each run. Set `IT_NO_BANNER=1` to disable it
+for scripting or CI environments.
 
 Each domain is available as a subcommand, e.g.:
 

--- a/cli/it_cli/__init__.py
+++ b/cli/it_cli/__init__.py
@@ -1,9 +1,9 @@
 """InfoTerminal CLI package."""
-__all__ = ["get_version"]
+from importlib import metadata
 
+try:
+    __version__ = metadata.version("infoterminal-cli")
+except metadata.PackageNotFoundError:
+    __version__ = "0.0.0.dev"
 
-def get_version() -> str:
-    """Return the CLI version from environment or fallback."""
-    import os
-
-    return os.environ.get("IT_VERSION", "dev")
+__all__ = ["__version__"]

--- a/cli/it_cli/__main__.py
+++ b/cli/it_cli/__main__.py
@@ -1,19 +1,36 @@
 """Entry point for InfoTerminal CLI."""
+from __future__ import annotations
+
+import os
+import sys
+
 import typer
 from rich.console import Console
 
+from . import __version__
 from .banner import print_banner
-from .commands import infra, search, graph, views, analytics, settings, tui
+from .commands import analytics, graph, infra, search, settings, tui, views
 from .plugins import load_plugins
 
-app = typer.Typer(no_args_is_help=True, help="InfoTerminal CLI – modular & pretty")
 console = Console()
+app = typer.Typer(no_args_is_help=True, help="InfoTerminal CLI – modular & pretty")
 
 
 @app.callback(invoke_without_command=True)
-def _root(ctx: typer.Context):  # noqa: D401 - minimal docstring
-    """Root callback printing banner."""
-    print_banner(console)
+def _root(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        is_eager=True,
+        help="Show version and exit",
+    ),
+):
+    """Handle root options like --version."""
+    if version:
+        console.print(f"it {__version__}")
+        raise typer.Exit()
 
 
 # register subcommands
@@ -29,5 +46,15 @@ app.add_typer(tui.app, name="ui", help="Textual TUI")
 load_plugins(app)
 
 
-if __name__ == "__main__":  # pragma: no cover - main entry
+def main() -> None:
+    """CLI entry point that prints banner before running Typer."""
+    if any(arg in ("-V", "--version") for arg in sys.argv[1:]):
+        console.print(f"it {__version__}")
+        raise SystemExit(0)
+    if os.environ.get("IT_NO_BANNER") != "1":
+        print_banner(console)
     app()
+
+
+if __name__ == "__main__":  # pragma: no cover - main entry
+    main()

--- a/cli/it_cli/banner.py
+++ b/cli/it_cli/banner.py
@@ -8,13 +8,19 @@ from rich import box
 from rich.panel import Panel
 from rich.text import Text
 
+from . import __version__
+
 
 def print_banner(console):
     """Render a simple InfoTerminal banner."""
-    title = Text(" InfoTerminal CLI ", style="bold white on blue")
-    meta = Text.assemble(
-        (" version ", "dim"), (os.environ.get("IT_VERSION", "dev"), "bold"),
-        (" • py ", "dim"), (platform.python_version(), "bold"),
-        (" • env ", "dim"), (os.environ.get("IT_ENV", "local"), "bold"),
-    )
-    console.print(Panel.fit(meta, title=title, border_style="blue", box=box.ROUNDED))
+    try:
+        title = Text(" InfoTerminal CLI ", style="bold white on blue")
+        meta = Text.assemble(
+            (" version ", "dim"), (__version__, "bold"),
+            (" • py ", "dim"), (platform.python_version(), "bold"),
+            (" • env ", "dim"), (os.environ.get("IT_ENV", "local"), "bold"),
+        )
+        console.print(Panel.fit(meta, title=title, border_style="blue", box=box.ROUNDED))
+    except Exception:
+        # Fallback to a plain banner without rich formatting
+        print("InfoTerminal CLI")

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.scripts]
-it = "it_cli.__main__:app"
+it = "it_cli.__main__:main"
 
 [project.entry-points."info_terminal.plugins"]
 # external packages can register their Typer apps here

--- a/tests/test_cli_banner_and_version.py
+++ b/tests/test_cli_banner_and_version.py
@@ -1,0 +1,43 @@
+"""Tests for CLI banner and version option."""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+from it_cli import __version__
+
+
+def _run_cli(args: list[str], env: dict[str, str] | None = None):
+    cmd = [sys.executable, "-m", "it_cli", *args]
+    env = env or os.environ.copy()
+    cli_path = pathlib.Path(__file__).resolve().parents[1] / "cli"
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(cli_path), env.get("PYTHONPATH", "")]
+    )
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def test_help_shows_banner():
+    result = _run_cli(["--help"])
+    assert result.returncode == 0
+    lines = result.stdout.splitlines()
+    assert not lines[0].startswith("Usage:")  # banner printed before help
+    assert "InfoTerminal CLI" in result.stdout
+
+
+def test_version_option_no_banner():
+    result = _run_cli(["-V"])
+    assert result.returncode == 0
+    assert result.stdout.strip() == f"it {__version__}"
+    assert "InfoTerminal CLI" not in result.stdout
+
+
+def test_no_banner_env(monkeypatch):
+    env = os.environ.copy()
+    env["IT_NO_BANNER"] = "1"
+    result = _run_cli(["--help"], env=env)
+    assert result.returncode == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert lines[0].lstrip().startswith("Usage:")


### PR DESCRIPTION
## Summary
- show InfoTerminal banner on every CLI invocation
- add global `--version/-V` option and expose package version
- allow disabling the banner via `IT_NO_BANNER=1`

## Testing
- `pytest tests/test_cli_banner_and_version.py tests/test_it_cli_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b959a18b4c83248e4d30cfe6f8b335