### PR TITLE
feat(frontend): unify theme and robust config

### DIFF
--- a/apps/frontend/components/Layout.tsx
+++ b/apps/frontend/components/Layout.tsx
@@ -17,11 +17,18 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             InfoTerminal
           </Link>
           <nav className="flex items-center gap-4 text-sm">
+            <Link href="/search">Search</Link>
+            <Link href="/graphx">GraphX</Link>
             <Link href="/settings">Settings</Link>
           </nav>
         </div>
       </header>
       <main className="container mx-auto max-w-7xl flex-1 p-6">{children}</main>
+      <footer className="border-t">
+        <div className="container mx-auto max-w-7xl p-4 text-sm text-gray-500">
+          © {new Date().getFullYear()} InfoTerminal
+        </div>
+      </footer>
     </div>
   );
 };

--- a/apps/frontend/lib/config.ts
+++ b/apps/frontend/lib/config.ts
@@ -1,9 +1,11 @@
-export const config = {
-  SEARCH_API:      process.env.NEXT_PUBLIC_SEARCH_API      ?? "http://127.0.0.1:8401",
-  GRAPH_API:       process.env.NEXT_PUBLIC_GRAPH_API       ?? "http://127.0.0.1:8402",
-  DOCENTITIES_API: process.env.NEXT_PUBLIC_DOCENTITIES_API ?? "http://127.0.0.1:8403",
-  VIEWS_API:       process.env.NEXT_PUBLIC_VIEWS_API       ?? "http://127.0.0.1:8403",
-  NLP_API:         process.env.NEXT_PUBLIC_NLP_API         ?? "http://127.0.0.1:8404",
-  GRAFANA_URL:     process.env.NEXT_PUBLIC_GRAFANA_URL,
+const config = {
+  SEARCH_API: process.env.NEXT_PUBLIC_SEARCH_API ?? "http://127.0.0.1:8401",
+  GRAPH_API: process.env.NEXT_PUBLIC_GRAPH_API ?? "http://127.0.0.1:8402",
+  DOCENTITIES_API:
+    process.env.NEXT_PUBLIC_DOCENTITIES_API ?? "http://127.0.0.1:8403",
+  VIEWS_API: process.env.NEXT_PUBLIC_VIEWS_API ?? "http://127.0.0.1:8403",
+  NLP_API: process.env.NEXT_PUBLIC_NLP_API ?? "http://127.0.0.1:8404",
+  GRAFANA_URL: process.env.NEXT_PUBLIC_GRAFANA_URL ?? "",
 } as const;
+
 export default config;

--- a/apps/frontend/lib/safe.ts
+++ b/apps/frontend/lib/safe.ts
@@ -1,5 +1,13 @@
 export const safe = <T>(v: T | undefined | null, fallback: T): T =>
   v == null ? fallback : v;
 
+/** Returns true when running in a browser environment. */
+export const isBrowser = (): boolean => typeof window !== "undefined";
+
+/** Optional logger that avoids SSR crashes. */
+export const safeLog = (...args: any[]) => {
+  if (isBrowser()) console.warn(...args);
+};
+
 export default safe;
 

--- a/apps/frontend/pages/graphx.tsx
+++ b/apps/frontend/pages/graphx.tsx
@@ -61,10 +61,10 @@ export default function GraphXPage() {
 
   return (
     <Layout>
-      <h1 className="mb-4 text-2xl font-semibold">GraphX</h1>
+      <h1 className="mb-4">GraphX</h1>
       <div className="space-y-6">
         <Card>
-          <h2 className="mb-2 text-lg font-semibold">Connections</h2>
+          <h2 className="mb-2">Connections</h2>
           <div className="flex flex-wrap gap-4">
             <div className="flex items-center gap-2">
               <Button onClick={pingGraph}>Ping Graph API</Button>
@@ -78,7 +78,7 @@ export default function GraphXPage() {
         </Card>
 
         <Card>
-          <h2 className="mb-2 text-lg font-semibold">Query</h2>
+          <h2 className="mb-2">Query</h2>
           <textarea
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -96,7 +96,7 @@ export default function GraphXPage() {
         </Card>
 
         <Card>
-          <h2 className="mb-2 text-lg font-semibold">Output</h2>
+          <h2 className="mb-2">Output</h2>
           {output ? (
             <pre className="max-h-96 overflow-auto text-xs">
               {JSON.stringify(output, null, 2)}

--- a/apps/frontend/pages/search.tsx
+++ b/apps/frontend/pages/search.tsx
@@ -50,7 +50,7 @@ export default function SearchPage() {
 
   return (
     <Layout>
-      <h1 className="mb-4 text-2xl font-semibold">Search</h1>
+      <h1 className="mb-4">Search</h1>
       <div className="mb-4 flex items-end gap-2">
         <Field
           label="Query"
@@ -78,7 +78,7 @@ export default function SearchPage() {
         {chips.map((c) => (
           <button
             key={c}
-            className="rounded-full bg-gray-200 px-3 py-1 text-xs"
+            className="rounded-full bg-gray-200 px-3 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-primary-500"
             onClick={() => setQ(c)}
           >
             {c}

--- a/apps/frontend/pages/settings.tsx
+++ b/apps/frontend/pages/settings.tsx
@@ -23,15 +23,6 @@ async function ping(url?: string): Promise<Status> {
 }
 
 export default function SettingsPage() {
-  if (!config) {
-    return (
-      <Layout>
-        <h1 className="mb-4 text-2xl font-semibold">Settings</h1>
-        <StatusPill status="fail">Config not loaded (check import)</StatusPill>
-      </Layout>
-    );
-  }
-
   const endpoints = [
     { key: "SEARCH_API", label: "Search API", url: config?.SEARCH_API },
     { key: "GRAPH_API", label: "Graph API", url: config?.GRAPH_API },
@@ -39,7 +30,9 @@ export default function SettingsPage() {
     { key: "VIEWS_API", label: "Views API", url: config?.VIEWS_API },
     { key: "NLP_API", label: "NLP API", url: config?.NLP_API },
   ];
-
+  const [values, setValues] = useState<Record<string, string>>(
+    Object.fromEntries(endpoints.map((e) => [e.key, e.url ?? ""]))
+  );
   const [status, setStatus] = useState<Record<string, Status>>({});
   const runtime = typeof window === "undefined" ? "server" : "client";
 
@@ -51,20 +44,28 @@ export default function SettingsPage() {
 
   return (
     <Layout>
-      <h1 className="mb-4 text-2xl font-semibold">Settings</h1>
+      <h1 className="mb-4">Settings</h1>
       <div className="space-y-6">
         <Card>
-          <h2 className="mb-2 text-lg font-semibold">Theme</h2>
+          <h2 className="mb-2">Theme</h2>
           <p className="text-sm text-gray-600">Dark mode toggle coming soon.</p>
         </Card>
 
         <Card>
-          <h2 className="mb-4 text-lg font-semibold">API Endpoints</h2>
+          <h2 className="mb-4">API Endpoints</h2>
           <div className="space-y-4">
             {endpoints.map((e) => (
               <div key={e.key} className="flex items-center gap-2">
-                <Field label={e.label} value={e.url ?? ""} readOnly className="flex-1" />
-                <Button onClick={() => handlePing(e.key, e.url)}>Ping</Button>
+                <Field
+                  label={e.label}
+                  value={values[e.key]}
+                  onChange={(ev) =>
+                    setValues((v) => ({ ...v, [e.key]: ev.target.value }))
+                  }
+                  helper={!e.url ? "Not configured" : undefined}
+                  className="flex-1"
+                />
+                <Button onClick={() => handlePing(e.key, values[e.key])}>Ping</Button>
                 {status[e.key] && <StatusPill status={status[e.key]} />}
               </div>
             ))}
@@ -72,7 +73,7 @@ export default function SettingsPage() {
         </Card>
 
         <Card>
-          <h2 className="mb-2 text-lg font-semibold">Environment</h2>
+          <h2 className="mb-2">Environment</h2>
           <ul className="text-sm text-gray-600">
             <li>NODE_ENV: {safe(process.env.NODE_ENV, "development")}</li>
             <li>Runtime: {runtime}</li>

--- a/apps/frontend/src/components/health/HealthPopover.tsx
+++ b/apps/frontend/src/components/health/HealthPopover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ServiceHealthCard from './ServiceHealthCard';
 import type { HealthResponse } from '../../../pages/api/health';
-import { GRAFANA_URL } from '../../../lib/config';
+import config from '../../../lib/config';
 
 interface Props {
   data: HealthResponse | null;
@@ -23,8 +23,13 @@ export const HealthPopover: React.FC<Props> = ({ data, onRefresh }) => {
         )}
       </div>
       <div className="mt-4 flex justify-end gap-4 text-sm">
-        {GRAFANA_URL && (
-          <a href={GRAFANA_URL} target="_blank" rel="noreferrer" className="text-blue-600">
+        {config.GRAFANA_URL && (
+          <a
+            href={config.GRAFANA_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-600"
+          >
             Open Grafana
           </a>
         )}

--- a/apps/frontend/styles/globals.css
+++ b/apps/frontend/styles/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  h1 {
+    @apply text-2xl font-semibold;
+  }
+  h2 {
+    @apply text-lg font-semibold;
+  }
+  :focus-visible {
+    @apply outline-none ring-2 ring-primary-500;
+  }
+}

--- a/docs/dev/Frontend-Modernisierung.md
+++ b/docs/dev/Frontend-Modernisierung.md
@@ -21,6 +21,13 @@ Diese umfassende Frontend-Modernisierung verwandelt das InfoTerminal von einer e
 - **📈 Performance Monitoring** - Web Vitals Tracking
 - **🔍 Advanced Search** - Faceted Search mit Reranking
 
+### Richtlinien für Theme & Config
+
+- Primärfarben werden in `tailwind.config.js` unter `theme.extend.colors.primary` definiert.
+- Fokus-Ringe nutzen konsequent `ring-primary-500` und sind global über `:focus-visible` aktiviert.
+- Konfiguration immer mit `import config from "@/lib/config"` einbinden (Default-Import).
+- API-Fehler führen nicht zum Absturz, sondern werden als Badge oder Hinweis im UI angezeigt.
+
 ### 🛠️ Technische Verbesserungen
 
 - **TypeScript** - Vollständige Typisierung


### PR DESCRIPTION
## Summary
- establish shared header/footer and global focus ring theming
- default-export config with fallbacks and safe helpers
- harden useHealth hook and make settings editable without crashing

## Testing
- `npm test` *(fails: React.Children.only expected to receive a single React element child)*
- `npm run build` *(fails: Type error in pages/analytics.tsx:156:13)*

------
https://chatgpt.com/codex/tasks/task_e_68b959b7120c8324ab03fef2cf86aba0