### PR TITLE
feat: improve CLI logs and tailwind setup

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,9 +18,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
-    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/line-clamp": "^0.4.4",
-    "@tailwindcss/typography": "^0.5.16",
     "cytoscape": "^3.28.0",
     "formidable": "^3.5.1",
     "isomorphic-unfetch": "^3.1.0",
@@ -35,8 +33,9 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
-    "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.12",
+    "@tailwindcss/postcss": "^4.1.12",
+    "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.0.0",
     "@types/node": "24.3.0",

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,10 @@ it --help
 
 # show version
 it -V
+
+# top-level aliases for infra commands
+it up -d                      # same as `it infra up`
+it logs -s search-api --follow      # tail logs and follow
 ```
 
 The CLI prints a banner on each run. Set `IT_NO_BANNER=1` to disable it
@@ -26,10 +30,10 @@ for scripting or CI environments.
 ### Infra commands
 
 ```bash
-# start local stack (alias: `start`)
+# start local stack (alias: `start` or top-level `it up`)
 it infra start -f docker-compose.yml -f docker-compose.override.yml -p myproj -d
 
-# stop services (aliases: `stop`, `halt`)
+# stop services (aliases: `stop`, `halt` or top-level `it down`)
 it infra stop -p myproj --services graph-api --services frontend
 
 # restart with extras
@@ -38,13 +42,16 @@ it infra restart --agents --gateway
 # check status for selected services
 it infra status -s search-api -s graph-api --timeout 5
 
-# tail logs for a service
+# tail & follow logs for a service
 it infra logs -s graph-api --compose-file docker-compose.yml -p myproj --follow
 ```
 
 Compose files and project names are discovered in this order of precedence:
 CLI flags > environment variables (`IT_COMPOSE_FILE`, `IT_PROJECT_NAME`) >
 auto-discovery (`docker-compose.yml`, `compose.yml`).
+
+Additional compose options like `--env-file`, `--profile` and multiple
+`--services` values are available for `up`, `down`, `restart` and `status`.
 
 Use `--dry-run` to print commands without executing them. `--verbose` shows
 subprocess calls, while `--quiet` minimizes output. Set `NO_COLOR=1` or use

--- a/cli/it_cli/__main__.py
+++ b/cli/it_cli/__main__.py
@@ -45,6 +45,15 @@ app.add_typer(tui.app, name="ui", help="Textual TUI")
 # load plugins
 load_plugins(app)
 
+# top-level aliases for infra commands
+app.command("up")(infra.up)
+app.command("down")(infra.down)
+app.command("start")(infra.up)
+app.command("stop")(infra.down)
+app.command("restart")(infra.restart)
+app.command("status")(infra.status)
+app.command("logs")(infra.logs)
+
 
 def main() -> None:
     """CLI entry point that prints banner before running Typer."""

--- a/cli/it_cli/commands/tui.py
+++ b/cli/it_cli/commands/tui.py
@@ -66,7 +66,10 @@ def run() -> None:
         def action_logs(self) -> None:  # pragma: no cover - UI
             if not self.table.rows:
                 return
-            service = self.table.get_row_at(self.table.cursor_row)[0]
-            infra.logs(service=service)
+            service = str(self.table.get_row_at(self.table.cursor_row)[0])
+            try:
+                infra.show_logs(service, lines=200, follow=False)
+            except FileNotFoundError:
+                console.print(f"No logs found for {service}")
 
     ITUI().run()

--- a/docs/dev/Frontend-Modernisierung.md
+++ b/docs/dev/Frontend-Modernisierung.md
@@ -60,6 +60,9 @@ cp tailwind.config.js tailwind.config.js.backup
 # Core Dependencies
 npm install @tailwindcss/forms @tailwindcss/typography @tailwindcss/line-clamp
 
+# Ab Next.js 14 ist das PostCSS-Plugin erforderlich
+npm install -D @tailwindcss/postcss
+
 # Optional Advanced Components
 npm install @headlessui/react @heroicons/react
 

--- a/tests/test_cli_logs.py
+++ b/tests/test_cli_logs.py
@@ -31,7 +31,7 @@ def test_logs_follow(monkeypatch, tmp_path):
         yield "y\n"
 
     monkeypatch.setattr(infra, "_follow_file", fake_follow)
-    result = runner.invoke(infra.app, ["logs", "--services", "search-api", "-f", "--lines", "1"])
+    result = runner.invoke(infra.app, ["logs", "--services", "search-api", "--follow", "--lines", "1"])
     assert result.exit_code == 0
     assert "x" in result.stdout and "y" in result.stdout
 
@@ -44,6 +44,6 @@ def test_logs_docker(monkeypatch):
         return SimpleNamespace(returncode=0, stderr="")
 
     monkeypatch.setattr(infra.subprocess, "run", fake_run)
-    result = runner.invoke(infra.app, ["logs", "--services", "neo4j", "--lines", "5", "-f"])
+    result = runner.invoke(infra.app, ["logs", "--services", "neo4j", "--lines", "5", "--follow"])
     assert result.exit_code == 0
     assert ["docker", "logs", "--tail", "5", "-f", "neo4j"] in calls

--- a/tests/test_it_cli_tui_logs.py
+++ b/tests/test_it_cli_tui_logs.py
@@ -1,0 +1,45 @@
+"""Tests for TUI log action."""
+from __future__ import annotations
+
+import types
+import sys
+
+from it_cli.commands import tui, infra
+
+
+def test_tui_logs_no_typeerror(monkeypatch):
+    calls = []
+
+    def fake_show_logs(service: str, lines: int = 0, follow: bool = False) -> None:
+        calls.append((service, lines, follow))
+
+    monkeypatch.setattr(infra, "show_logs", fake_show_logs)
+
+    class DummyTable:
+        def __init__(self) -> None:
+            self.rows = [("search-api",)]
+            self.cursor_row = 0
+
+        def get_row_at(self, idx: int):
+            return self.rows[idx]
+
+    class DummyApp:
+        BINDINGS = []
+
+        def __init__(self) -> None:
+            self.table = DummyTable()
+
+        def run(self) -> None:
+            self.action_logs()
+
+        # placeholders for abstract methods
+        def compose(self):  # pragma: no cover - not used
+            return []
+
+    dummy_app = types.SimpleNamespace(App=DummyApp, ComposeResult=list)
+    dummy_widgets = types.SimpleNamespace(DataTable=DummyTable, Footer=object, Header=object)
+    monkeypatch.setitem(sys.modules, "textual.app", dummy_app)
+    monkeypatch.setitem(sys.modules, "textual.widgets", dummy_widgets)
+
+    tui.run()
+    assert calls == [("search-api", 200, False)]


### PR DESCRIPTION
## What changed
- centralize infra log streaming into pure `show_logs`
- add top level `it up|down|status|restart|logs` commands
- handle log display inside TUI without crashing
- fix frontend Tailwind PostCSS deps and docs

## How to test
- `pipx install --force ./cli && it -V && it infra --help`
- `pytest tests/test_cli_banner_and_version.py tests/test_cli_logs.py tests/test_it_cli_tui_logs.py`
- `cd apps/frontend && npm i && npm run dev`

## Known gaps
- none


------
https://chatgpt.com/codex/tasks/task_e_68b96903681c8324abaf6bd120e4ef65