### PR TITLE
codex: fix tailwind globals and add postgres dev infra

### DIFF
--- a/apps/frontend/postcss.config.js
+++ b/apps/frontend/postcss.config.js
@@ -1,1 +1,3 @@
-module.exports = { plugins: { '@tailwindcss/postcss': {}, autoprefixer: {} } }
+module.exports = {
+  plugins: [require('@tailwindcss/postcss'), require('autoprefixer')],
+};

--- a/apps/frontend/src/styles/globals.css
+++ b/apps/frontend/src/styles/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @layer base {
   h1 {

--- a/cli/README.md
+++ b/cli/README.md
@@ -63,7 +63,9 @@ subprocess calls, while `--quiet` minimizes output. Set `NO_COLOR=1` or use
 it ui run
 
 # Key bindings within the TUI:
-#   r refresh   u up   d down   s status   l logs of selected service
+#   r refresh   u up   d down   s status   l logs   f follow logs
+# Die TUI ruft den internen Helper `show_logs` aus `infra` auf –
+# Typer-Commands selbst werden im UI nicht verwendet.
 ```
 
 ### Other examples

--- a/cli/it_cli/commands/infra.py
+++ b/cli/it_cli/commands/infra.py
@@ -263,7 +263,7 @@ def up(
             cmd.append("-d")
         execute(cmd, run_env, dry_run, verbose, quiet)
     else:
-        base_services = services if services else ["opensearch", "neo4j"]
+        base_services = services if services else ["opensearch", "neo4j", "postgres"]
         cmd = compose_cmd(["up"] + (["-d"] if detach else []) + base_services, compose_files, project, profiles)
         try:
             execute(cmd, run_env, dry_run, verbose, quiet, check=True, capture_output=True, text=True)

--- a/cli/it_cli/commands/tui.py
+++ b/cli/it_cli/commands/tui.py
@@ -27,6 +27,7 @@ def run() -> None:
             ("d", "down", "Down"),
             ("s", "status", "Status"),
             ("l", "logs", "Logs"),
+            ("f", "follow_logs", "Follow"),
         ]
 
         def compose(self) -> ComposeResult:  # pragma: no cover - UI
@@ -69,6 +70,15 @@ def run() -> None:
             service = str(self.table.get_row_at(self.table.cursor_row)[0])
             try:
                 infra.show_logs(service, lines=200, follow=False)
+            except FileNotFoundError:
+                console.print(f"No logs found for {service}")
+
+        def action_follow_logs(self) -> None:  # pragma: no cover - UI
+            if not self.table.rows:
+                return
+            service = str(self.table.get_row_at(self.table.cursor_row)[0])
+            try:
+                infra.show_logs(service, lines=200, follow=True)
             except FileNotFoundError:
                 console.print(f"No logs found for {service}")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,20 @@ services:
       retries: 20
     volumes:
       - neo4j_data:/data
+  postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=it_user
+      - POSTGRES_PASSWORD=it_pass
+      - POSTGRES_DB=it_graph
+    ports: ['5432:5432']
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
   # Optional modules --------------------------------------------------
   prometheus:
     profiles: ["observability"]

--- a/docs/dev/Frontend-Modernisierung.md
+++ b/docs/dev/Frontend-Modernisierung.md
@@ -27,6 +27,7 @@ Diese umfassende Frontend-Modernisierung verwandelt das InfoTerminal von einer e
 - Fokus-Ringe nutzen konsequent `ring-primary-500` und sind global über `:focus-visible` aktiviert.
 - Konfiguration immer mit `import config from "@/lib/config"` einbinden (Default-Import).
 - API-Fehler führen nicht zum Absturz, sondern werden als Badge oder Hinweis im UI angezeigt.
+- Das globale Stylesheet `src/styles/globals.css` bindet ganz oben `@import "tailwindcss";` ein, danach folgen eigene `@layer`-Regeln.
 
 ### 🛠️ Technische Verbesserungen
 


### PR DESCRIPTION
## Summary
- align Tailwind v4 global style imports and PostCSS pipeline
- add postgres to compose infra and expose in CLI helpers
- improve TUI log viewer with follow support and document usage

## Testing
- `cd apps/frontend && npm run dev`
- `cd apps/frontend && npm test`
- `pytest`
- `python -m cli.it_cli infra up`
- `curl -fsS http://127.0.0.1:8403/healthz`
- `python -m cli.it_cli infra status`


------
https://chatgpt.com/codex/tasks/task_e_68b976c14f908324a686b103a274ae2c