### PR TITLE
search-api: standardisierte /healthz & /readyz + Tests + Operability-Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - doc-entities liefert Entitäten inklusive Kontext
 - Demo-Daten Seeds und NiFi "ingest-demo" Template
 - Release-Dokumentation und Roadmap aktualisiert
+- search-api: standardisierte /healthz & /readyz Endpoints mit Tests

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -1,0 +1,36 @@
+# Operability
+
+## Dev Ports
+- Frontend: 3411
+- search-api: 8401
+- graph-api: 8402
+- graph-views: 8403
+- agents: 3417
+- gateway: 8610
+
+## Health Endpoints
+- `GET /healthz` – liveness
+- `GET /readyz` – readiness
+
+Both endpoints return JSON in the form:
+```json
+{
+  "status": "ok|degraded|fail",
+  "service": "<name>",
+  "version": "<git-sha|dev>",
+  "time": "<UTC ISO8601>",
+  "uptime_s": <float>,
+  "checks": { ... }  // only on /readyz
+}
+```
+
+`/healthz` performs no external checks. `/readyz` reports dependency checks in `checks`. Each check contains a `status` of `ok`, `fail` or `skipped` with optional details.
+
+## Environment Flags
+- `IT_FORCE_READY`: when set to `1`, `/readyz` skips external checks and reports ready.
+- `OPENSEARCH_URL`: if set, `/readyz` probes OpenSearch with a short timeout. When unset, the check is marked `skipped`.
+
+## Troubleshooting
+- Ensure the Neo4j development password has at least 8 characters.
+- Restrict CORS in development to `http://localhost:3411`.
+- Disable OTEL exporters in development unless needed.

--- a/services/search-api/app/health.py
+++ b/services/search-api/app/health.py
@@ -1,0 +1,74 @@
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict
+from urllib import request
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _base_payload(request: Request) -> Dict[str, Any]:
+    service = request.app.state.service_name
+    version = getattr(request.app.state, "version", os.getenv("GIT_SHA", "dev"))
+    start_time = getattr(request.app.state, "start_time", time.time())
+    return {
+        "status": "ok",
+        "service": service,
+        "version": version,
+        "time": datetime.now(timezone.utc).isoformat(),
+        "uptime_s": time.time() - start_time,
+    }
+
+
+@router.get("/healthz")
+def healthz(request: Request):
+    payload = _base_payload(request)
+    return JSONResponse(payload)
+
+
+@router.get("/readyz")
+def readyz(request: Request):
+    payload = _base_payload(request)
+    checks: Dict[str, Any] = {}
+    status = "ok"
+
+    if os.getenv("IT_FORCE_READY") == "1":
+        checks["opensearch"] = {"status": "skipped", "reason": "IT_FORCE_READY"}
+    else:
+        os_url = os.getenv("OPENSEARCH_URL")
+        if os_url:
+            start = time.perf_counter()
+            try:
+                with request.urlopen(os_url, timeout=0.8) as resp:
+                    code = resp.getcode()
+                    latency = (time.perf_counter() - start) * 1000
+                    if 200 <= code < 300 or code == 401:
+                        checks["opensearch"] = {
+                            "status": "ok",
+                            "latency_ms": round(latency, 2),
+                        }
+                    else:
+                        checks["opensearch"] = {
+                            "status": "fail",
+                            "code": code,
+                        }
+                        status = "fail"
+            except Exception as e:  # pragma: no cover - network errors
+                checks["opensearch"] = {
+                    "status": "fail",
+                    "reason": str(e),
+                }
+                status = "fail"
+        else:
+            checks["opensearch"] = {
+                "status": "skipped",
+                "reason": "OPENSEARCH_URL not set",
+            }
+
+    payload["checks"] = checks
+    payload["status"] = status
+    http_status = 200 if status == "ok" else 503
+    return JSONResponse(payload, status_code=http_status)

--- a/services/search-api/tests/test_health.py
+++ b/services/search-api/tests/test_health.py
@@ -1,7 +1,21 @@
 import pytest
 
+
 @pytest.mark.anyio
 async def test_health(client):
     r = await client.get("/healthz")
+    data = r.json()
     assert r.status_code == 200
-    assert r.json().get("status") in ("ok", "healthy")
+    assert data["status"] == "ok"
+    for key in ("service", "version", "time", "uptime_s"):
+        assert key in data
+
+
+@pytest.mark.anyio
+async def test_ready_force(client, monkeypatch):
+    monkeypatch.setenv("IT_FORCE_READY", "1")
+    r = await client.get("/readyz")
+    data = r.json()
+    assert r.status_code == 200
+    assert data["status"] == "ok"
+    assert "checks" in data


### PR DESCRIPTION
## Summary
- add standardized `/healthz` and `/readyz` endpoints to search-api
- capture OpenSearch readiness with small timeout and skip options
- document service ports, health endpoints, and env flags

## Testing
- `pre-commit run --files services/search-api/app/health.py services/search-api/app/main.py services/search-api/tests/test_health.py docs/OPERABILITY.md CHANGELOG.md`
- `cd services/search-api && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96cf987248324a7082de4734287ef