### PR TITLE
Health v2 (graph-api & graph-views) + Frontend Health Matrix + Settings endpoints

### DIFF
--- a/apps/frontend/pages/api/health.ts
+++ b/apps/frontend/pages/api/health.ts
@@ -17,7 +17,7 @@ async function ping(url: string): Promise<{ state: ServiceState; latencyMs: numb
   const timeout = setTimeout(() => controller.abort(), 5000);
   const start = Date.now();
   try {
-    const res = await fetch(url + '/healthz', { signal: controller.signal });
+    const res = await fetch(url + '/readyz', { signal: controller.signal });
     const latencyMs = Date.now() - start;
     clearTimeout(timeout);
     if (!res.ok) {
@@ -26,7 +26,7 @@ async function ping(url: string): Promise<{ state: ServiceState; latencyMs: numb
     const info = await res.json().catch(() => ({}));
     let state: ServiceState = 'ok';
     if (info.status === 'degraded') state = 'degraded';
-    else if (info.status === 'down') state = 'down';
+    else if (info.status === 'fail') state = 'down';
     else if (info.status !== 'ok') state = 'unreachable';
     return { state, latencyMs, info };
   } catch {

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -26,9 +26,24 @@ Both endpoints return JSON in the form:
 
 `/healthz` performs no external checks. `/readyz` reports dependency checks in `checks`. Each check contains a `status` of `ok`, `fail` or `skipped` with optional details.
 
+### `search-api`
+- Probes OpenSearch with a short HTTP request (~0.8s timeout) when `OPENSEARCH_URL` is set.
+- Example `checks` entry: `{ "opensearch": { "status": "ok", "latency_ms": 42.1 } }`
+- If OpenSearch URL is missing the check is `skipped`.
+
+### `graph-api`
+- Probes Neo4j via `RETURN 1` with ~0.8s timeout.
+- Example `checks` entry: `{ "neo4j": { "status": "ok", "latency_ms": 12.3 } }`
+- Missing Neo4j connection details result in a `skipped` check.
+
+### `graph-views`
+- Probes Postgres via `SELECT 1` with ~0.8s timeout.
+- Example `checks` entry: `{ "postgres": { "status": "ok", "latency_ms": 5.1 } }`
+- If the connection pool cannot be initialised the check is `skipped`.
+
 ## Environment Flags
 - `IT_FORCE_READY`: when set to `1`, `/readyz` skips external checks and reports ready.
-- `OPENSEARCH_URL`: if set, `/readyz` probes OpenSearch with a short timeout. When unset, the check is marked `skipped`.
+- Missing connection details for a dependency result in a `skipped` check with a reason.
 
 ## Troubleshooting
 - Ensure the Neo4j development password has at least 8 characters.

--- a/services/graph-api/health.py
+++ b/services/graph-api/health.py
@@ -1,0 +1,75 @@
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from neo4j import exceptions as neo_exceptions
+
+from utils.neo4j_client import neo_session
+
+router = APIRouter()
+
+
+def _base_payload(request: Request) -> Dict[str, Any]:
+    service = request.app.state.service_name
+    version = getattr(request.app.state, "version", os.getenv("GIT_SHA", "dev"))
+    start_time = getattr(request.app.state, "start_time", time.time())
+    return {
+        "status": "ok",
+        "service": service,
+        "version": version,
+        "time": datetime.now(timezone.utc).isoformat(),
+        "uptime_s": time.time() - start_time,
+    }
+
+
+@router.get("/healthz")
+def healthz(request: Request):
+    payload = _base_payload(request)
+    return JSONResponse(payload)
+
+
+@router.get("/readyz")
+def readyz(request: Request):
+    payload = _base_payload(request)
+    checks: Dict[str, Any] = {}
+    status = "ok"
+
+    if os.getenv("IT_FORCE_READY") == "1":
+        checks["neo4j"] = {"status": "skipped", "reason": "IT_FORCE_READY"}
+    else:
+        uri = os.getenv("NEO4J_URI")
+        user = os.getenv("NEO4J_USER")
+        password = os.getenv("NEO4J_PASS") or os.getenv("NEO4J_PASSWORD")
+        driver = getattr(request.app.state, "driver", None)
+        if uri and user and password and driver:
+            start = time.perf_counter()
+            try:
+                with neo_session(driver) as s:
+                    s.run("RETURN 1").consume()
+                latency = (time.perf_counter() - start) * 1000
+                checks["neo4j"] = {
+                    "status": "ok",
+                    "latency_ms": round(latency, 2),
+                }
+            except neo_exceptions.AuthError:
+                checks["neo4j"] = {"status": "fail", "reason": "auth"}
+                status = "fail"
+            except Exception as e:  # pragma: no cover - network errors
+                checks["neo4j"] = {
+                    "status": "fail",
+                    "reason": str(e),
+                }
+                status = "fail"
+        else:
+            checks["neo4j"] = {
+                "status": "skipped",
+                "reason": "NEO4J configuration missing",
+            }
+
+    payload["checks"] = checks
+    payload["status"] = status
+    http_status = 200 if status == "ok" else 503
+    return JSONResponse(payload, status_code=http_status)

--- a/services/graph-views/health.py
+++ b/services/graph-views/health.py
@@ -1,0 +1,71 @@
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _base_payload(request: Request) -> Dict[str, Any]:
+    service = request.app.state.service_name
+    version = getattr(request.app.state, "version", os.getenv("GIT_SHA", "dev"))
+    start_time = getattr(request.app.state, "start_time", time.time())
+    return {
+        "status": "ok",
+        "service": service,
+        "version": version,
+        "time": datetime.now(timezone.utc).isoformat(),
+        "uptime_s": time.time() - start_time,
+    }
+
+
+@router.get("/healthz")
+def healthz(request: Request):
+    payload = _base_payload(request)
+    return JSONResponse(payload)
+
+
+@router.get("/readyz")
+def readyz(request: Request):
+    payload = _base_payload(request)
+    checks: Dict[str, Any] = {}
+    status = "ok"
+
+    if os.getenv("IT_FORCE_READY") == "1":
+        checks["postgres"] = {"status": "skipped", "reason": "IT_FORCE_READY"}
+    else:
+        pool = getattr(request.app.state, "pool", None)
+        if pool:
+            start = time.perf_counter()
+            conn = None
+            try:
+                conn = pool.getconn()
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+                latency = (time.perf_counter() - start) * 1000
+                checks["postgres"] = {
+                    "status": "ok",
+                    "latency_ms": round(latency, 2),
+                }
+            except Exception as e:  # pragma: no cover - network errors
+                checks["postgres"] = {
+                    "status": "fail",
+                    "reason": str(e),
+                }
+                status = "fail"
+            finally:
+                if conn:
+                    pool.putconn(conn)
+        else:
+            checks["postgres"] = {
+                "status": "skipped",
+                "reason": "PG pool not initialised",
+            }
+
+    payload["checks"] = checks
+    payload["status"] = status
+    http_status = 200 if status == "ok" else 503
+    return JSONResponse(payload, status_code=http_status)

--- a/services/graph-views/tests/test_health.py
+++ b/services/graph-views/tests/test_health.py
@@ -1,35 +1,77 @@
 import os, sys
 from pathlib import Path
-os.environ.setdefault("INIT_DB_ON_STARTUP", "0")  # vermeidet echten PG-Connect
+
+os.environ.setdefault("INIT_DB_ON_STARTUP", "0")
 os.environ.setdefault("OTEL_SDK_DISABLED", "1")
+
 sys.path.append(Path(__file__).resolve().parents[1].as_posix())
-from fastapi.testclient import TestClient
-import app as app_module
-from app import app, socket
-from contextlib import contextmanager
+import types
+sys.modules.setdefault(
+    "opentelemetry.instrumentation.fastapi",
+    types.SimpleNamespace(
+        FastAPIInstrumentor=type("FastAPIInstrumentor", (), {"instrument_app": lambda self, app: app})
+    ),
+)
+import app as app_module  # noqa: E402
+from app import app  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 
-@contextmanager
-def _dummy_conn():
-  class DummyCur:
+class DummyCur:
     def execute(self, *a, **k):
-      pass
-    def __enter__(self): return self
-    def __exit__(self, *a): pass
-  class DummyConn:
-    def cursor(self): return DummyCur()
-  yield DummyConn()
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        pass
 
 
-def test_healthz_ok(monkeypatch):
-  class DummySock:
-    def __enter__(self): return self
-    def __exit__(self, *a): pass
+class DummyConn:
+    def cursor(self):
+        return DummyCur()
 
-  monkeypatch.setattr(app_module, "pool", object())
-  monkeypatch.setattr(app_module, "conn", lambda: _dummy_conn())
-  monkeypatch.setattr(socket, "create_connection", lambda *a, **k: DummySock())
-  with TestClient(app) as c:
-    r = c.get("/healthz")
-    assert r.status_code == 200
-    assert r.json().get("ok") is True
+
+class DummyPool:
+    def getconn(self):
+        return DummyConn()
+    def putconn(self, conn):  # pragma: no cover - trivial
+        pass
+    def closeall(self):  # pragma: no cover - trivial
+        pass
+
+
+def _patch_pool(monkeypatch):
+    monkeypatch.setattr(app_module, "setup_pool", lambda: DummyPool())
+
+
+def test_healthz(monkeypatch):
+    _patch_pool(monkeypatch)
+    with TestClient(app) as c:
+        r = c.get("/healthz")
+        data = r.json()
+        assert r.status_code == 200
+        assert data["status"] == "ok"
+        for key in ("service", "version", "time", "uptime_s"):
+            assert key in data
+
+
+def test_ready_force(monkeypatch):
+    _patch_pool(monkeypatch)
+    monkeypatch.setenv("IT_FORCE_READY", "1")
+    with TestClient(app) as c:
+        r = c.get("/readyz")
+        data = r.json()
+        assert r.status_code == 200
+        assert data["status"] == "ok"
+        assert data["checks"]["postgres"]["status"] == "skipped"
+
+
+def test_ready_skipped(monkeypatch):
+    monkeypatch.setattr(app_module, "setup_pool", lambda: None)
+    monkeypatch.delenv("IT_FORCE_READY", raising=False)
+    with TestClient(app) as c:
+        r = c.get("/readyz")
+        data = r.json()
+        assert r.status_code == 200
+        assert data["status"] == "ok"
+        assert data["checks"]["postgres"]["status"] == "skipped"


### PR DESCRIPTION
## Summary
- standardize health and readiness endpoints for graph-api and graph-views with Neo4j and Postgres pings
- document new readiness checks and environment flags
- poll /readyz endpoints from frontend health API

## Testing
- `cd services/graph-api && .venv/bin/pytest -q`
- `cd services/graph-views && .venv/bin/pytest -q`
- `cd apps/frontend && npm test` *(fails: React.Children.only expected a single element and canvas not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68b98da0e1b083248a675f14dce183bd