### PR TITLE
chore: enforce coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+omit =
+    */__init__.py
+    */migrations/*
+    apps/frontend/*
+    */tests/*
+
+[report]
+show_missing = True
+fail_under = 100
+

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -43,6 +43,7 @@
     "@types/node": "24.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.21",
     "husky": "^9.1.7",
     "install": "^0.13.0",

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -13,6 +13,13 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'src/__tests__/**/*.{ts,tsx}'],
     exclude: ['e2e/**', 'node_modules/**'],
-    coverage: { reporter: ['text', 'json', 'lcov'] }
+    coverage: {
+      reporter: ['text', 'json', 'lcov'],
+      lines: 100,
+      functions: 100,
+      branches: 100,
+      statements: 100,
+      exclude: ['.next/**']
+    }
   }
 });

--- a/data/demo/loaded.json
+++ b/data/demo/loaded.json
@@ -1,1 +1,5 @@
-{}
+{
+  "91583503f35e5c1ee20ef6f2c51d72e7f4dbfd99": {
+    "file": "demo2.txt"
+  }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,11 +6,17 @@ This repository targets **100% line and branch coverage** for all project code. 
 
 ### Python services and CLI
 
+`pytest` is configured via `pytest.ini` to measure branch coverage and fail when
+coverage drops below 100 %.
+
 ```bash
-pytest --cov --cov-report=term-missing
+pytest
 ```
 
 ### Frontend
+
+The frontend uses `vitest` with coverage thresholds set to 100 % for all
+metrics.
 
 ```bash
 npm test -- --coverage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+addopts = --cov --cov-branch --cov-report=term-missing --cov-report=xml --cov-fail-under=100
+testpaths =
+    services
+    cli
+    tests
+python_files = test_*.py *_test.py
+


### PR DESCRIPTION
## Summary
- add global coverage config and pytest settings enforcing 100%
- require 100% coverage in frontend vitest and install coverage plugin
- document unified test and coverage workflow

## Testing
- `pytest` *(fails: import file mismatch and missing app.main)*
- `npm test -- --coverage` *(fails: unable to find element in search-page spec)*
- `pre-commit run --files .coveragerc pytest.ini docs/testing.md apps/frontend/vitest.config.ts apps/frontend/package.json` *(fails: interrupted during hook environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b998b147b88324bee9ba08ae19e5c2