### PR TITLE
chore(graph-views): add asyncpg dependency

### DIFF
--- a/services/graph-views/README.md
+++ b/services/graph-views/README.md
@@ -1,0 +1,27 @@
+# Graph Views Service
+
+This service exposes graph-related views via FastAPI.
+
+## Development
+
+Create a virtual environment and install the package in editable mode:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .
+```
+
+The editable install includes the asynchronous PostgreSQL driver `asyncpg` used by `db.py`.
+
+For running tests install the dev requirements:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Start the service during development with:
+
+```bash
+IT_FORCE_READY=1 uvicorn app:app --port 8403 --reload
+```

--- a/services/graph-views/pyproject.toml
+++ b/services/graph-views/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "graph-views"
 version = "0.1.0"
@@ -7,6 +11,7 @@ dependencies = [
     "uvicorn>=0.30",
     "pydantic>=2.7",
     "psycopg2-binary>=2.9",
+    "asyncpg>=0.28",
     "python-dotenv>=1.0",
     "opentelemetry-sdk>=1.26.0",
     "opentelemetry-exporter-otlp>=1.26.0",
@@ -16,6 +21,9 @@ dependencies = [
     "prometheus-client>=0.20",
     "starlette-exporter>=0.15",
 ]
+
+[tool.setuptools]
+py-modules = ["app", "db", "it_logging", "metrics"]
 
 [tool.uv]
 index-url = "https://pypi.org/simple"

--- a/services/graph-views/requirements-dev.txt
+++ b/services/graph-views/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=8.2
+pytest-cov>=5.0
+httpx>=0.27


### PR DESCRIPTION
## Summary
- declare asyncpg dependency for graph-views
- document asyncpg install and dev setup
- provide service-level dev requirements

## Testing
- `pip install -e .` *(fails: previously due to packaging; after fix, succeeded)*
- `IT_FORCE_READY=1 uvicorn app:app --port 8403 --reload` *(pass: server started, then terminated)*
- `pytest graph-views/tests -q -p pytest_cov` *(fail: coverage threshold not met)*
- `pre-commit run --files services/graph-views/pyproject.toml services/graph-views/requirements-dev.txt services/graph-views/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68bcc706b59c8324b3048c39f7f77a65