### PR TITLE
Add Dockerfiles for core services and web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Die Plattform kombiniert Volltextsuche, Graph-Analyse und Dokumentenmanagement â
 
 ```bash
 cp .env.example .env
+docker compose build
 docker compose up -d
 ````
 

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["node_modules/.bin/next", "start", "-p", "3000"]

--- a/services/graph-api/Dockerfile
+++ b/services/graph-api/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -e .
+
+EXPOSE 8080
+HEALTHCHECK CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz')" || exit 1
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/graph-views/Dockerfile
+++ b/services/graph-views/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+RUN pip install --no-cache-dir -e .
+
+EXPOSE 8000
+HEALTHCHECK CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz')" || exit 1
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/search-api/Dockerfile
+++ b/services/search-api/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -e .
+
+EXPOSE 8080
+HEALTHCHECK CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz')" || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- add minimal Dockerfiles for search-api, graph-api, graph-views, and frontend
- document `docker compose build` in quickstart

## Testing
- `docker compose build` *(fails: command not found: docker)*
- `python -m cli.it_cli start -d` *(fails: No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68bccce4dabc8324a1941a401dc83d04