### PR TITLE
graph-views: depend on asyncpg

### DIFF
--- a/services/graph-views/README.md
+++ b/services/graph-views/README.md
@@ -12,7 +12,7 @@ python -m venv .venv
 pip install -e .
 ```
 
-The editable install includes the asynchronous PostgreSQL driver `asyncpg` used by `db.py`.
+Graph-Views initialisiert Postgres asynchron via `asyncpg`; die Abhängigkeit ist Bestandteil des Pakets.
 
 For running tests install the dev requirements:
 

--- a/services/graph-views/pyproject.toml
+++ b/services/graph-views/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "graph-views"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.111",
     "uvicorn>=0.30",
     "pydantic>=2.7",
-    "psycopg2-binary>=2.9",
-    "asyncpg>=0.28",
+    # "psycopg2-binary>=2.9",  # legacy sync client; currently unused
+    "asyncpg>=0.30",
     "python-dotenv>=1.0",
     "opentelemetry-sdk>=1.26.0",
     "opentelemetry-exporter-otlp>=1.26.0",


### PR DESCRIPTION
## Summary
- include asyncpg as runtime dependency for graph-views
- comment out unused psycopg2-binary dependency
- document asyncpg usage in graph-views README

## Testing
- `pytest tests` *(fails: Coverage failure: total of 54 is less than fail-under=92)*
- `pytest tests --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68bd424ac05483248bdb5200e676940c