### PR TITLE
docs: add CLI cheatsheet

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,61 @@ it status -n --format json
 it logs -n -s neo4j --lines 10
 ```
 
+## CLI Cheatsheet
+
+Kurzer Überblick über wichtige Befehle. Ausführliche Hilfe liefert `it --help` und `it infra --help`.
+
+### Schnellstart
+
+```bash
+# Infra (Datenbanken & Engines)
+docker compose -f docker-compose.neo.yml up -d
+
+# Observability (Prometheus/Grafana/…)
+docker compose -f docker-compose.observability.yml --profile observability up -d
+
+# Core Apps
+docker compose up -d web search-api graph-api graph-views gateway
+
+# NLP (optional)
+docker compose -f docker-compose.nlp.yml up -d
+```
+
+### Häufige it-Befehle
+
+```bash
+it start -n -f docker-compose.yml -p dev -s neo4j,opensearch
+it stop -s graph-api
+it restart -s search-api --timeout 10
+it rm -v --images local             # compose down --remove-orphans + Volumes + Local-Images
+it status --format json              # docker compose ps --format json
+it logs -s neo4j --lines 200 -F      # logs erfordert --services
+```
+
+### Flags im Alltag
+
+- `-f/--compose-file` (wiederholbar), `-p/--project-name`, `--env-file`, `--profile` (wiederholbar)
+- `-s/--services` (kommagetrennt oder mehrfach), `-n/--dry-run`, `--verbose`, `-q/--quiet`, `-d/--detach`
+- Banner steuern: `IT_NO_BANNER=1`
+- Version: `it -V`
+- Shell-Completion: `it --install-completion`
+
+### Wann welches Compose?
+
+| Aufgabe             | Datei/Profil                                                   | Beispiel                                                                           |
+| ------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Datenbanken/Engines | `docker-compose.neo.yml`                                       | `docker compose -f docker-compose.neo.yml up -d`                                   |
+| Observability       | `docker-compose.observability.yml` + `--profile observability` | `docker compose -f docker-compose.observability.yml --profile observability up -d` |
+| Core Apps           | `docker-compose.yml`                                           | `docker compose up -d web search-api graph-api graph-views gateway`                |
+| NLP (optional)      | `docker-compose.nlp.yml`                                       | `docker compose -f docker-compose.nlp.yml up -d`                                   |
+
+### Stolpersteine
+
+- `--profile` hat nur Effekt für Services mit `profiles`.
+- Fehlende Dockerfiles → nur in den vorgesehenen Stacks starten (z. B. `docker-compose.nlp.yml`).
+- Ports sind absichtlich non-standard (siehe Port-Policy), Konflikte vermeiden.
+- `it logs` benötigt immer `--services`.
+
 ### Flags
 
 Common flags are available across commands:
@@ -63,9 +118,9 @@ Specific flags:
 | --- | --- |
 | `start` | `-d/--detach`, `--retries`, `--timeout` |
 | `restart` | `--retries`, `--timeout` |
-| `rm` | `-v/--volumes`, `--images [all|local|none]` (use `--verbose` for verbosity) |
-| `status` | `--format [table|text|json|yaml]` |
-| `logs` | `-F/--follow`, `--lines N`, `--format [plain|jsonl]` |
+| `rm` | `-v/--volumes`, `--images [all\|local\|none]` (use `--verbose` for verbosity) |
+| `status` | `--format [table\|text\|json\|yaml]` |
+| `logs` | `-F/--follow`, `--lines N`, `--format [plain\|jsonl]` |
 
 Use `--dry-run` to print the composed `docker compose` command without
 executing it. `--verbose` prints subprocess output, `--quiet` suppresses

--- a/docs/OPERABILITY.md
+++ b/docs/OPERABILITY.md
@@ -22,6 +22,8 @@ Beispiele:
 
 Hinweis: `--profile infra` NICHT auf dem Haupt-Compose verwenden; Services ohne `profiles` starten immer.
 
+Siehe auch das [CLI Cheatsheet](../cli/README.md#cli-cheatsheet).
+
 Metrics and tracing can be enabled with `IT_ENABLE_METRICS=1` and `IT_OTEL=1`.
 
 ## Ports


### PR DESCRIPTION
## Summary
- add CLI Cheatsheet with stack start commands, common `it` usage and flags
- cross-reference cheatsheet from operability guide

## Testing
- `npx markdownlint-cli "**/*.md"` *(fails: many existing markdownlint issues)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68bd469b40d8832484d3b351ae524e9f