### PR TITLE
chore(env): ensure v0.2 env keys for auth/metrics/ports and feature flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,6 @@ GRAFANA_PORT=3413
 ALERTMANAGER_PORT=3414
 LOKI_PORT=3415
 TEMPO_PORT=3416
-# Enable /metrics endpoints (set to 1 to expose)
-IT_ENABLE_METRICS=0
 
 # Tracing / OTEL (set IT_OTEL=1 to enable)
 IT_OTEL=0
@@ -81,6 +79,7 @@ IT_OIDC_AUDIENCE=infoterminal
 IT_OIDC_JWKS_URL=http://localhost:8080/realms/infoterminal/protocol/openid-connect/certs
 
 # Observability (opt-in)
+IT_ENABLE_METRICS=0
 IT_REQUEST_ID_HEADER=X-Request-Id
 
 # Ports (authoritative via patch_ports.sh)


### PR DESCRIPTION
## Summary
- ensure metrics and auth env keys present in env example

## Testing
- `pytest` *(fails: Plugin already registered under a different name: /workspace/InfoTerminal/services/graph-views/tests/conftest.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c54e7f341c8324a14d6966faf9869a