### PR TITLE
feat(agent): extend connector with playbooks and n8n

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,14 @@ NLP_DEFAULT_LANG=en
 NLP_BACKEND=spacy           # spacy|transformers
 NLP_SPACY_MODEL_EN=en_core_web_sm
 NLP_SPACY_MODEL_DE=de_core_news_sm
-# Agent / Flowise
+# Agent / Flowise / n8n
 AGENT_BASE_URL=http://localhost:3417
+AGENT_TIMEOUT_MS=120000
 AGENT_PLAYBOOKS=static
+N8N_BASE_URL=http://localhost:5678
+N8N_API_KEY=
+N8N_WEBHOOK_URL=
+
+# Geospatial
+NEXT_PUBLIC_MAP_TILES=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+GEO_UPLOAD_DIR=/data/geo

--- a/docs/dev/en/SMOKETESTS_agent_graph_geo.md
+++ b/docs/dev/en/SMOKETESTS_agent_graph_geo.md
@@ -1,0 +1,23 @@
+# Smoke Tests: Agent, Graph, Geospatial
+
+```bash
+# Agent tools
+curl -s http://localhost:8610/tools | jq .
+
+# Playbook
+curl -s -X POST http://localhost:8610/playbooks/run -H 'Content-Type: application/json' \
+  -d '{"name":"InvestigatePerson","params":{"q":"Alice"}}' | jq .
+
+# Chat (stub if AGENT_BASE_URL unset)
+curl -s -X POST http://localhost:8610/chat -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"Find links between Alice and ACME."}]}' | jq .
+
+# Graph algorithms
+curl -s -X POST http://localhost:8612/alg/degree -H 'Content-Type: application/json' -d '{}' | jq .
+curl -s -X POST http://localhost:8612/alg/betweenness -H 'Content-Type: application/json' -d '{}' | jq .
+curl -s -X POST http://localhost:8612/alg/communities -H 'Content-Type: application/json' -d '{}' | jq .
+
+# Geo upload
+curl -s -X POST http://localhost:8403/geo/upload -F 'file=@examples/sample.geojson' | jq .
+curl -s http://localhost:8403/geo/list | jq .
+```

--- a/docs/dev/en/automation/n8n.md
+++ b/docs/dev/en/automation/n8n.md
@@ -1,0 +1,22 @@
+# n8n Automation Guide
+
+The agent connector can trigger n8n workflows either via a preconfigured webhook URL or the REST API.
+
+## Webhook
+
+Set `N8N_WEBHOOK_URL` in the environment. The connector will POST the playbook parameters to this URL.
+
+## REST API
+
+Configure `N8N_BASE_URL` and `N8N_API_KEY`. The connector calls `POST /rest/workflows/run` with the given `params`.
+
+Example for the `FinancialRiskAssistant`:
+
+```json
+{
+  "name": "FinancialRiskAssistant",
+  "params": {"account": "123"}
+}
+```
+
+The response contains the trigger status and optional run information.

--- a/services/flowise-connector/app/main.py
+++ b/services/flowise-connector/app/main.py
@@ -1,7 +1,9 @@
-import os, time
+import os, time, uuid
 from typing import Optional, Dict, Any
 import httpx
 from fastapi import FastAPI, HTTPException, Header
+from starlette.requests import Request
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette_exporter import PrometheusMiddleware, handle_metrics
 try:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -9,10 +11,24 @@ except Exception:
     FastAPIInstrumentor = None
 
 AGENT_BASE_URL = os.getenv("AGENT_BASE_URL", "")
+AGENT_TIMEOUT = int(os.getenv("AGENT_TIMEOUT_MS", "120000"))
 FLOWISE_API_KEY = os.getenv("FLOWISE_API_KEY", "")
-TIMEOUT = float(os.getenv("FLOWISE_TIMEOUT_S", "30"))
+N8N_BASE = os.getenv("N8N_BASE_URL")
+N8N_KEY = os.getenv("N8N_API_KEY")
+N8N_WEBHOOK = os.getenv("N8N_WEBHOOK_URL")
+
+REQ_ID_HEADER = os.getenv("IT_REQUEST_ID_HEADER", "X-Request-Id")
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        req_id = request.headers.get(REQ_ID_HEADER) or str(uuid.uuid4())
+        request.state.request_id = req_id
+        response = await call_next(request)
+        response.headers[REQ_ID_HEADER] = req_id
+        return response
 
 app = FastAPI(title="Flowise Connector", version="0.1.0")
+app.add_middleware(RequestIdMiddleware)
 if os.getenv("IT_ENABLE_METRICS") == "1":
     app.add_middleware(PrometheusMiddleware)
     app.add_route("/metrics", handle_metrics)
@@ -36,9 +52,10 @@ def readyz():
 def tools():
     return {
         "tools": [
-            {"name": "search.query"},
-            {"name": "graph.neighbors"},
-            {"name": "docs.ner"},
+            {"name": "search.query", "args": {"q": "string"}},
+            {"name": "graph.neighbors", "args": {"nodeId": "string", "depth": "number"}},
+            {"name": "docs.ner", "args": {"text": "string", "lang": "string"}},
+            {"name": "dossier.build", "args": {"payload": "object"}},
         ]
     }
 
@@ -46,9 +63,32 @@ def tools():
 @app.post("/playbooks/run")
 async def run_playbook(pb: Dict[str, Any]):
     name = pb.get("name")
-    if name == "InvestigatePerson":
-        # Placeholder steps; real implementation would call search-api, graph-api and doc-entities
-        return {"steps": ["search", "graph.neighbors", "docs.ner"], "result": {}}
+    params = pb.get("params", {})
+    search_url = f"http://localhost:{os.getenv('IT_PORT_SEARCH_API','8611')}"
+    graph_url = f"http://localhost:{os.getenv('IT_PORT_GRAPH_API','8612')}"
+    nlp_url = f"http://localhost:{os.getenv('IT_PORT_DOC_ENTITIES','8613')}"
+    async with httpx.AsyncClient(timeout=30) as client:
+        if name == "InvestigatePerson":
+            q = params.get("q", "")
+            s = await client.get(f"{search_url}/search", params={"q": q})
+            s.raise_for_status()
+            results = s.json()
+            return {"name": name, "results": results}
+        if name == "FinancialRiskAssistant":
+            if N8N_WEBHOOK:
+                r = await client.post(N8N_WEBHOOK, json=params)
+                r.raise_for_status()
+                return {"name": name, "status": "triggered", "n8n": "webhook"}
+            if N8N_BASE and N8N_KEY:
+                r = await client.post(
+                    f"{N8N_BASE}/rest/workflows/run",
+                    headers={"X-N8N-API-KEY": N8N_KEY},
+                    json={"params": params},
+                )
+                r.raise_for_status()
+                data = r.json() if r.content else {}
+                return {"name": name, "status": "triggered", "n8n": "rest", "response": data}
+            return {"name": name, "status": "configured=false"}
     raise HTTPException(404, "unknown playbook")
 
 
@@ -56,7 +96,7 @@ async def run_playbook(pb: Dict[str, Any]):
 async def chat(body: Dict[str, Any], authorization: Optional[str] = Header(None)):
     if not AGENT_BASE_URL:
         last = (body.get("messages") or [{}])[-1].get("content", "")
-        return {"reply": f"stub: {last}"}
+        return {"reply": "(stub) Agent not configured; using local tools only.", "steps": []}
 
     headers = {"Content-Type": "application/json"}
     if FLOWISE_API_KEY:
@@ -66,9 +106,30 @@ async def chat(body: Dict[str, Any], authorization: Optional[str] = Header(None)
 
     url = f"{AGENT_BASE_URL}/api/v1/prediction"
     try:
-        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        async with httpx.AsyncClient(timeout=AGENT_TIMEOUT/1000) as client:
             r = await client.post(url, json=body, headers=headers)
         r.raise_for_status()
         return r.json()
     except httpx.HTTPError as e:
         raise HTTPException(status_code=502, detail=str(e))
+
+
+@app.post("/workflows/trigger")
+async def trigger_workflow(body: Dict[str, Any]):
+    name = body.get("name")
+    params = body.get("params", {})
+    async with httpx.AsyncClient(timeout=30) as client:
+        if N8N_WEBHOOK:
+            r = await client.post(N8N_WEBHOOK, json={"name": name, "params": params})
+            r.raise_for_status()
+            return {"status": "triggered", "n8n": "webhook"}
+        if N8N_BASE and N8N_KEY:
+            r = await client.post(
+                f"{N8N_BASE}/rest/workflows/run",
+                headers={"X-N8N-API-KEY": N8N_KEY},
+                json={"name": name, "params": params},
+            )
+            r.raise_for_status()
+            data = r.json() if r.content else {}
+            return {"status": "triggered", "n8n": "rest", "response": data}
+    raise HTTPException(500, "n8n not configured")


### PR DESCRIPTION
## Summary
- add agent, n8n, and geospatial defaults to env example
- extend Flowise connector with tools endpoint, playbook runner, chat proxy, and n8n trigger
- document n8n automation and provide smoke tests for agent/graph/geo

## Testing
- `pytest -q services/graph-api/tests/test_health.py` *(fails: ModuleNotFoundError: No module named 'app')*
- `pytest services/flowise-connector`

------
https://chatgpt.com/codex/tasks/task_e_68c556df0400832482057f0e325cdea1