### PR TITLE
feat(frontend): surface Agent and NLP across navigation

### DIFF
--- a/apps/frontend/e2e/specs/sidebar.agent-nlp.spec.ts
+++ b/apps/frontend/e2e/specs/sidebar.agent-nlp.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure sidebar exposes Agent and NLP links and navigation works
+// Feature flags default to enabled in dev via ff util
+
+test('sidebar exposes Agent and NLP and navigates', async ({ page }) => {
+  await page.goto(process.env.E2E_BASE_URL || 'http://localhost:3411/');
+  await expect(page.getByRole('link', { name: 'Agent' })).toBeVisible();
+  await page.getByRole('link', { name: 'Agent' }).click();
+  await expect(page).toHaveURL(/\/(agent)(\/)?/);
+  await expect(page.getByRole('link', { name: 'NLP' })).toBeVisible();
+  await page.getByRole('link', { name: 'NLP' }).click();
+  await expect(page).toHaveURL(/\/(nlp)(\/)?/);
+});

--- a/apps/frontend/pages/index.tsx
+++ b/apps/frontend/pages/index.tsx
@@ -1,22 +1,25 @@
 // apps/frontend/pages/index.tsx - Moderne Dashboard Homepage
 import { useEffect, useState } from 'react';
-import { 
-  Search, 
-  FileText, 
-  Network, 
-  TrendingUp, 
-  Users, 
+import {
+  Search,
+  FileText,
+  Network,
+  TrendingUp,
+  Users,
   Database,
   Activity,
   ArrowUpRight,
   ArrowDownRight,
   BarChart3,
   Clock,
-  AlertTriangle
+  AlertTriangle,
+  Bot,
+  Sparkles
 } from 'lucide-react';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import Panel from '@/components/layout/Panel';
 import { useHealth } from '@/hooks/useHealth';
+import { ff } from '@/components/navItems';
 
 interface DashboardStats {
   totalDocuments: number;
@@ -195,6 +198,24 @@ export default function Dashboard() {
                 icon={BarChart3}
                 color="orange"
               />
+              {ff('NEXT_PUBLIC_FEATURE_AGENT') && (
+                <QuickActionCard
+                  title="Investigation Agent"
+                  description="Chat with your data"
+                  href="/agent"
+                  icon={Bot}
+                  color="green"
+                />
+              )}
+              {ff('NEXT_PUBLIC_FEATURE_NLP') && (
+                <QuickActionCard
+                  title="NLP Playground"
+                  description="Experiment with language models"
+                  href="/nlp"
+                  icon={Sparkles}
+                  color="purple"
+                />
+              )}
             </div>
           </Panel>
         </div>

--- a/apps/frontend/src/components/layout/DashboardLayout.tsx
+++ b/apps/frontend/src/components/layout/DashboardLayout.tsx
@@ -3,56 +3,17 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import {
-  Search,
-  BarChart3,
-  Network,
-  FileText,
   Settings,
   Bell,
   Menu,
   X,
-  Home,
-  Users,
-  Database,
-  Shield,
   Activity,
-  MessageSquare,
-  Sparkles
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import GlobalHealth from '../health/GlobalHealth';
 import { ThemeToggle } from '@/components/layout/ThemeToggle';
+import { NAV_ITEMS, isEnabled, type NavItem } from '@/components/navItems';
 
-interface NavigationItem {
-  name: string;
-  href: string;
-  icon: LucideIcon;
-  badge?: number;
-}
-
-import { extraNav, isEnabled } from '@/components/navItems';
-
-const baseNavigation: NavigationItem[] = [
-  { name: 'Dashboard', href: '/', icon: Home },
-  { name: 'Search', href: '/search', icon: Search },
-  { name: 'Graph', href: '/graphx', icon: Network },
-  { name: 'Documents', href: '/documents', icon: FileText },
-  { name: 'Analytics', href: '/analytics', icon: BarChart3 },
-  { name: 'Entities', href: '/entities', icon: Users },
-  { name: 'Data', href: '/data', icon: Database },
-  { name: 'Security', href: '/security', icon: Shield }
-];
-
-const navigation: NavigationItem[] = [...baseNavigation];
-
-extraNav.filter(isEnabled).forEach((item) => {
-  if (!navigation.find((n) => n.href === item.href)) {
-    let icon = MessageSquare as LucideIcon;
-    if (item.icon === 'Sparkles') icon = Sparkles;
-    if (item.icon === 'MessageSquare') icon = MessageSquare;
-    navigation.push({ name: item.label, href: item.href, icon });
-  }
-});
+const navigation = NAV_ITEMS.filter(isEnabled);
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -111,7 +72,7 @@ export default function DashboardLayout({ children, title, subtitle }: Dashboard
           aria-label="Sidebar"
           className="fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 shadow-xl focus:outline-none"
         >
-          <SidebarContent currentPath={router.pathname} onClose={() => setSidebarOpen(false)} />
+          <SidebarContent items={navigation} currentPath={router.pathname} onClose={() => setSidebarOpen(false)} />
         </div>
       </div>
 
@@ -122,7 +83,7 @@ export default function DashboardLayout({ children, title, subtitle }: Dashboard
         aria-label="Sidebar"
         className="hidden lg:fixed lg:inset-y-0 lg:z-40 lg:flex lg:w-64 lg:flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800"
       >
-        <SidebarContent currentPath={router.pathname} />
+        <SidebarContent items={navigation} currentPath={router.pathname} />
       </aside>
 
       {/* Main content */}
@@ -175,11 +136,12 @@ export default function DashboardLayout({ children, title, subtitle }: Dashboard
 }
 
 interface SidebarContentProps {
+  items: NavItem[];
   currentPath?: string;
   onClose?: () => void;
 }
 
-function SidebarContent({ currentPath, onClose }: SidebarContentProps) {
+function SidebarContent({ items, currentPath, onClose }: SidebarContentProps) {
   return (
     <div className="flex h-full flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800">
       {/* Logo */}
@@ -199,7 +161,7 @@ function SidebarContent({ currentPath, onClose }: SidebarContentProps) {
 
       {/* Navigation */}
       <nav className="flex-1 px-3 py-4 space-y-1">
-        {navigation.map((item) => {
+        {items.map((item) => {
           const cp = currentPath || '';
           const isActive = cp === item.href || 
             (item.href !== '/' && cp.startsWith(item.href));

--- a/apps/frontend/src/components/mobile/MobileNavigation.tsx
+++ b/apps/frontend/src/components/mobile/MobileNavigation.tsx
@@ -2,46 +2,16 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import {
-  Home,
-  Search,
-  Network,
-  FileText,
-  BarChart3,
   Settings,
   Menu,
   X,
   Bell,
   User,
-  MessageSquare,
-  Sparkles
 } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import { useNotifications } from '@/lib/notifications';
-import { extraNav, isEnabled } from '@/components/navItems';
+import { NAV_ITEMS, isEnabled, type NavItem } from '@/components/navItems';
 
-interface MobileNavItem {
-  name: string;
-  href: string;
-  icon: LucideIcon;
-  badge?: number;
-}
-
-const navigationItems: MobileNavItem[] = [
-  { name: 'Dashboard', href: '/', icon: Home },
-  { name: 'Search', href: '/search', icon: Search },
-  { name: 'Graph', href: '/graphx', icon: Network },
-  { name: 'Documents', href: '/documents', icon: FileText },
-  { name: 'Analytics', href: '/analytics', icon: BarChart3 },
-];
-
-extraNav.filter(isEnabled).forEach(item => {
-  if (!navigationItems.find(n => n.href === item.href)) {
-    let icon = MessageSquare as LucideIcon;
-    if (item.icon === 'Sparkles') icon = Sparkles;
-    if (item.icon === 'MessageSquare') icon = MessageSquare;
-    navigationItems.push({ name: item.label, href: item.href, icon });
-  }
-});
+const navigationItems: NavItem[] = NAV_ITEMS.filter(isEnabled);
 
 export function MobileNavigation() {
   const router = useRouter();

--- a/apps/frontend/src/components/navItems.ts
+++ b/apps/frontend/src/components/navItems.ts
@@ -1,15 +1,45 @@
-export type NavItem = { key: string; href: string; label: string; icon?: string; featureFlag?: string };
+import type { LucideIcon } from "lucide-react";
+import {
+  Home,
+  Search,
+  Network,
+  FileText,
+  BarChart3,
+  Users,
+  Database,
+  Shield,
+  Bot,
+  Sparkles,
+} from "lucide-react";
 
-export const baseNav: NavItem[] = [
-  // existing core nav items could be added here in future
+export type NavItem = {
+  key: string;
+  name: string;
+  href: string;
+  icon: LucideIcon;
+  featureFlag?: string;
+  badge?: number;
+};
+
+export const NAV_ITEMS: NavItem[] = [
+  { key: "dashboard", name: "Dashboard", href: "/", icon: Home },
+  { key: "search", name: "Search", href: "/search", icon: Search },
+  { key: "graph", name: "Graph", href: "/graphx", icon: Network },
+  { key: "agent", name: "Agent", href: "/agent", icon: Bot, featureFlag: "NEXT_PUBLIC_FEATURE_AGENT" },
+  { key: "documents", name: "Documents", href: "/documents", icon: FileText },
+  { key: "nlp", name: "NLP", href: "/nlp", icon: Sparkles, featureFlag: "NEXT_PUBLIC_FEATURE_NLP" },
+  { key: "analytics", name: "Analytics", href: "/analytics", icon: BarChart3 },
+  { key: "entities", name: "Entities", href: "/entities", icon: Users },
+  { key: "data", name: "Data", href: "/data", icon: Database },
+  { key: "security", name: "Security", href: "/security", icon: Shield },
 ];
 
-export const extraNav: NavItem[] = [
-  { key: "agent", href: "/agent", label: "Agent", icon: "MessageSquare", featureFlag: "NEXT_PUBLIC_FEATURE_AGENT" },
-  { key: "nlp", href: "/nlp", label: "NLP", icon: "Sparkles", featureFlag: "NEXT_PUBLIC_FEATURE_NLP" },
-];
+export const ff = (k: string) => {
+  const v = process.env[k];
+  if (v === undefined) return true;
+  return v === "1" || v.toLowerCase() === "true";
+};
 
 export function isEnabled(item: NavItem) {
-  if (!item.featureFlag) return true;
-  return process.env[item.featureFlag] === "1" || process.env[item.featureFlag] === "true";
+  return !item.featureFlag || ff(item.featureFlag);
 }

--- a/docs/dev/en/frontend/NAVIGATION.md
+++ b/docs/dev/en/frontend/NAVIGATION.md
@@ -1,5 +1,5 @@
 # Frontend Navigation
 
-The sidebar aggregates navigation items from `baseNav` and `extraNav` in `src/components/navItems.ts`. Items `agent` and `nlp` are behind the `NEXT_PUBLIC_FEATURE_AGENT` and `NEXT_PUBLIC_FEATURE_NLP` flags.
+The sidebar is driven by `NAV_ITEMS` in `apps/frontend/src/components/navItems.ts`. The list defines the order: *Agent* follows **Graph**, *NLP* follows **Documents**. Visibility is gated by the `NEXT_PUBLIC_FEATURE_AGENT` and `NEXT_PUBLIC_FEATURE_NLP` flags (unset ⇒ enabled in dev).
 
-Both desktop and mobile menus use the same list. Mobile links close the menu on navigation.
+Both desktop and mobile menus consume the same filtered items and the mobile drawer closes on navigation.

--- a/docs/user/de/navigation.md
+++ b/docs/user/de/navigation.md
@@ -1,3 +1,3 @@
 # Navigation
 
-Die Seiten **Agent** und **NLP** sind über die Sidebar erreichbar. Beide Einträge lassen sich über die Umgebungsvariablen `NEXT_PUBLIC_FEATURE_AGENT` und `NEXT_PUBLIC_FEATURE_NLP` ein- oder ausblenden.
+Die Seiten **Agent** und **NLP** sind über die Sidebar erreichbar. *Agent* erscheint zwischen **Graph** und **Documents**, *NLP* zwischen **Documents** und **Analytics**. Beide Einträge lassen sich über die Umgebungsvariablen `NEXT_PUBLIC_FEATURE_AGENT` und `NEXT_PUBLIC_FEATURE_NLP` ein- oder ausblenden.


### PR DESCRIPTION
## Summary
- add feature-flag helper defaulting to enabled when unset
- expose Agent after Graph and NLP after Documents in sidebar and mobile nav
- document navigation flags and add dashboard quick actions

## Testing
- `pnpm lint` *(fails: Code style issues found in 149 files)*
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find module 'react-leaflet')*
- `pnpm e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c56f36d89483248a447d5df272da28