### PR TITLE
refactor(agent): centralize http client with timeouts, selective retry and structured errors

### DIFF
--- a/services/flowise-connector/app/__init__.py
+++ b/services/flowise-connector/app/__init__.py
@@ -1,0 +1,5 @@
+"""Flowise connector app package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/services/flowise-connector/app/errors.py
+++ b/services/flowise-connector/app/errors.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AgentUpstreamError(Exception):
+    status: int
+    detail: str
+    upstream: str
+
+
+@dataclass
+class WorkflowTriggerError(Exception):
+    status: int
+    detail: str
+    upstream: str

--- a/services/flowise-connector/app/http_client.py
+++ b/services/flowise-connector/app/http_client.py
@@ -1,0 +1,42 @@
+import asyncio
+import os
+from typing import Any, Optional
+
+import httpx
+
+DEFAULT_TIMEOUT = float(os.getenv("IT_HTTP_TIMEOUT", "15"))
+
+
+async def request(
+    method: str,
+    url: str,
+    *,
+    headers: Optional[dict[str, str]] = None,
+    params: Optional[dict[str, Any]] = None,
+    json: Any | None = None,
+) -> httpx.Response:
+    """Perform an HTTP request with unified timeout and optional retry for GET."""
+    timeout = httpx.Timeout(DEFAULT_TIMEOUT)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        attempts = 3 if method.upper() == "GET" else 1
+        delay = 0.5
+        last_exc: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                resp = await client.request(
+                    method,
+                    url,
+                    headers=headers,
+                    params=params,
+                    json=json,
+                )
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPError as exc:  # pragma: no cover - exercised via tests
+                last_exc = exc
+                if attempt + 1 == attempts:
+                    raise
+                await asyncio.sleep(delay)
+                delay *= 2
+        assert last_exc  # for mypy
+        raise last_exc

--- a/services/flowise-connector/app/it_logging.py
+++ b/services/flowise-connector/app/it_logging.py
@@ -1,0 +1,114 @@
+import json
+import logging
+import logging.config
+import os
+import time
+import uuid
+from datetime import datetime
+from typing import Set
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class RequestLogMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, service_name: str, env: str):
+        super().__init__(app)
+        self.logger = logging.getLogger(service_name)
+        sample = os.getenv("IT_LOG_SAMPLING", "/healthz,/metrics")
+        self.skip_paths: Set[str] = {p for p in sample.split(",") if p}
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        req_id = (
+            request.headers.get("X-Request-Id")
+            or getattr(request.state, "request_id", None)
+            or str(uuid.uuid4())
+        )
+        request.state.req_id = req_id
+        start = time.time()
+        status = 500
+        response: Response | None = None
+        try:
+            response = await call_next(request)
+            status = response.status_code
+            return response
+        finally:
+            duration = (time.time() - start) * 1000
+            path = request.url.path
+            if response is not None:
+                response.headers.setdefault("X-Request-Id", req_id)
+            if path not in self.skip_paths or status >= 400:
+                extra = {
+                    "req_id": req_id,
+                    "method": request.method,
+                    "path": path,
+                    "status": status,
+                    "dur_ms": round(duration, 3),
+                }
+                if request.client:
+                    extra["client_ip"] = request.client.host
+                self.logger.info("request", extra=extra)
+
+
+def setup_logging(app, service_name: str):
+    if os.getenv("IT_JSON_LOGS", "1") != "1":
+        return
+    log_level = os.getenv("IT_LOG_LEVEL", "INFO").upper()
+    env = os.getenv("IT_ENV", "dev")
+
+    class JsonFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple
+            ts = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+            data = {
+                "ts": ts,
+                "level": record.levelname.lower(),
+                "service": service_name,
+                "env": env,
+            }
+            for key in (
+                "req_id",
+                "client_ip",
+                "method",
+                "path",
+                "status",
+                "dur_ms",
+            ):
+                val = getattr(record, key, None)
+                if val is not None:
+                    data[key] = val
+            data["msg"] = record.getMessage()
+            return json.dumps(data, separators=(",", ":"))
+
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"json": {"()": JsonFormatter}},
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "json",
+            },
+            "null": {"class": "logging.NullHandler"},
+        },
+        "root": {"handlers": ["default"], "level": log_level},
+        "loggers": {
+            "uvicorn": {
+                "handlers": ["default"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "handlers": ["default"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["null"],
+                "level": log_level,
+                "propagate": False,
+            },
+        },
+    }
+    logging.config.dictConfig(logging_config)
+    app.add_middleware(RequestLogMiddleware, service_name=service_name, env=env)

--- a/services/flowise-connector/tests/conftest.py
+++ b/services/flowise-connector/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
+os.environ.setdefault("IT_JSON_LOGS", "1")
+os.environ.setdefault("IT_ENV", "test")
+os.environ.setdefault("IT_LOG_SAMPLING", "")
+
+service_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(service_dir))
+import app.main as app_main  # type: ignore  # noqa: E402
+
+app = app_main.app
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c

--- a/services/flowise-connector/tests/test_errors.py
+++ b/services/flowise-connector/tests/test_errors.py
@@ -1,0 +1,48 @@
+import logging
+
+import httpx
+import pytest
+
+import app.main as main
+
+
+@pytest.mark.anyio
+async def test_chat_upstream_error(client, monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+
+    async def boom(method, url, **kwargs):
+        request = httpx.Request("POST", url)
+        response = httpx.Response(500, request=request)
+        raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+    monkeypatch.setenv("AGENT_BASE_URL", "http://agent")
+    main.AGENT_BASE_URL = "http://agent"
+    monkeypatch.setattr(main, "http_request", boom)
+
+    resp = await client.post("/chat", json={"messages": []})
+    assert resp.status_code == 500
+    assert resp.json() == {
+        "status": 500,
+        "detail": "server error",
+        "upstream": "http://agent/api/v1/prediction",
+    }
+    rec = next(rec for rec in caplog.records if rec.msg == "agent_error")
+    assert rec.req_id == resp.headers["X-Request-Id"]
+
+
+@pytest.mark.anyio
+async def test_workflow_timeout(client, monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+
+    async def boom(method, url, **kwargs):
+        raise httpx.TimeoutException("timeout")
+
+    monkeypatch.setenv("N8N_WEBHOOK", "http://n8n/hook")
+    main.N8N_WEBHOOK = "http://n8n/hook"
+    monkeypatch.setattr(main, "http_request", boom)
+
+    resp = await client.post("/workflows/trigger", json={"name": "x"})
+    assert resp.status_code == 408
+    assert resp.json()["upstream"] == "http://n8n/hook"
+    rec = next(rec for rec in caplog.records if rec.msg == "workflow_error")
+    assert rec.req_id == resp.headers["X-Request-Id"]


### PR DESCRIPTION
## Summary
- centralize Flowise connector HTTP usage with shared async client and 15s timeout
- add AgentUpstreamError and WorkflowTriggerError with structured JSON responses
- emit structured request logs carrying request IDs

## Testing
- `pre-commit run --files services/flowise-connector/tests/conftest.py services/flowise-connector/tests/test_errors.py services/flowise-connector/app/__init__.py services/flowise-connector/app/errors.py services/flowise-connector/app/http_client.py services/flowise-connector/app/it_logging.py services/flowise-connector/app/main.py`
- `PYTEST_ADDOPTS="--no-cov" pytest services/flowise-connector/tests/test_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68c65e9505588324803b29596253a289