### PR TITLE
feat: add robust query serialization utility

### DIFF
--- a/apps/frontend/.eslintrc.json
+++ b/apps/frontend/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": "NewExpression[callee.name='URLSearchParams'] ObjectExpression",
+        "message": "Use toSearchParams(...) instead of direct object initialization."
+      }
+    ]
+  }
+}

--- a/apps/frontend/pages/search.tsx
+++ b/apps/frontend/pages/search.tsx
@@ -1,24 +1,25 @@
 import { useRef, useState, useEffect } from "react";
-import { 
-  Search, 
-  Filter, 
-  SortAsc, 
-  Calendar, 
-  FileText, 
-  Users, 
-  MapPin, 
+import {
+  Search,
+  Filter,
+  SortAsc,
+  Calendar,
+  FileText,
+  Users,
+  MapPin,
   Clock,
   Star,
   ExternalLink,
   Download,
   Eye,
-  Loader
-} from 'lucide-react';
+  Loader,
+} from "lucide-react";
 import DashboardLayout from "@/components/layout/DashboardLayout";
 import Panel from "@/components/layout/Panel";
 import config from "@/lib/config";
 import DossierButton from "@/components/DossierButton";
 import dynamic from "next/dynamic";
+import { toSearchParams } from "@/lib/url";
 const MapPanel = dynamic(() => import("@/components/MapPanel"), { ssr: false });
 
 interface SearchResult {
@@ -47,21 +48,21 @@ const SEARCH_SUGGESTIONS = [
   { text: "entity connections", category: "Graph" },
   { text: "risk indicators", category: "Analysis" },
   { text: "John Smith", category: "People" },
-  { text: "London office", category: "Locations" }
+  { text: "London office", category: "Locations" },
 ];
 
 const SORT_OPTIONS = [
   { value: "relevance", label: "Relevance", icon: Star },
   { value: "date_desc", label: "Newest First", icon: Calendar },
   { value: "date_asc", label: "Oldest First", icon: Calendar },
-  { value: "score", label: "Score", icon: SortAsc }
+  { value: "score", label: "Score", icon: SortAsc },
 ];
 
 const RESULT_TYPES = [
   { value: "all", label: "All Results", count: null },
   { value: "document", label: "Documents", count: null },
   { value: "entity", label: "Entities", count: null },
-  { value: "connection", label: "Connections", count: null }
+  { value: "connection", label: "Connections", count: null },
 ];
 
 export default function SearchPage() {
@@ -73,14 +74,14 @@ export default function SearchPage() {
   const [showMap, setShowMap] = useState(false);
   const [totalResults, setTotalResults] = useState(0);
   const [searchTime, setSearchTime] = useState(0);
-  
+
   const [filters, setFilters] = useState<SearchFilters>({
     type: "all",
     dateRange: "all",
     source: "all",
-    minScore: 0
+    minScore: 0,
   });
-  
+
   const [sort, setSort] = useState("relevance");
   const controller = useRef<AbortController | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -94,16 +95,16 @@ export default function SearchPage() {
     const searchTerm = searchQuery || query;
     if (!searchTerm.trim()) return;
 
-    const params = new URLSearchParams({ 
-      q: searchTerm, 
-      sort, 
-      limit: "20",
-      ...filters 
+    const params = toSearchParams({
+      q: searchTerm,
+      sort,
+      limit: 20,
+      ...filters,
     });
-    
+
     setIsLoading(true);
     setError(null);
-    
+
     // Cancel previous request
     controller.current?.abort();
     const c = new AbortController();
@@ -113,22 +114,21 @@ export default function SearchPage() {
 
     try {
       let response = await fetch(`/api/search?${params.toString()}`, { signal: c.signal });
-      
+
       if (response.status === 404) {
         const base = config?.SEARCH_API;
         if (!base) throw new Error("Search API not configured");
         response = await fetch(`${base}/search?${params.toString()}`, { signal: c.signal });
       }
-      
+
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      
+
       const data = await response.json();
       const searchResults = data.items || data.results || [];
-      
+
       setResults(searchResults);
       setTotalResults(data.total || searchResults.length);
       setSearchTime(Math.round(performance.now() - startTime));
-      
     } catch (e: any) {
       if (e.name !== "AbortError") {
         setError(e.message || "Search failed");
@@ -139,7 +139,7 @@ export default function SearchPage() {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+    if (e.key === "Enter") {
       runSearch();
     }
   };
@@ -165,12 +165,12 @@ export default function SearchPage() {
       results,
       totalResults,
       searchTime,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     };
 
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
     a.download = `search-results-${Date.now()}.json`;
     a.click();
@@ -180,7 +180,6 @@ export default function SearchPage() {
   return (
     <DashboardLayout title="Intelligent Search" subtitle="Search across all your data sources">
       <div className="max-w-7xl mx-auto space-y-6">
-        
         {/* Search Header */}
         <div className="space-y-4">
           <div className="relative">
@@ -218,7 +217,9 @@ export default function SearchPage() {
                     className="inline-flex items-center gap-2 px-3 py-2 text-sm bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-slate-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
                   >
                     <span>{suggestion.text}</span>
-                    <span className="text-xs text-gray-500 dark:text-slate-400">({suggestion.category})</span>
+                    <span className="text-xs text-gray-500 dark:text-slate-400">
+                      ({suggestion.category})
+                    </span>
                   </button>
                 ))}
               </div>
@@ -227,10 +228,8 @@ export default function SearchPage() {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          
           {/* Main Content */}
           <div className="lg:col-span-3 space-y-6">
-            
             {/* Search Controls */}
             <div className="flex items-center justify-between bg-white dark:bg-gray-900 p-4 rounded-lg border border-gray-200 dark:border-gray-700">
               <div className="flex items-center gap-4">
@@ -246,9 +245,9 @@ export default function SearchPage() {
                 <button
                   onClick={() => setShowFilters(!showFilters)}
                   className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-                    showFilters 
-                      ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-slate-300 dark:hover:bg-gray-700'
+                    showFilters
+                      ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-slate-300 dark:hover:bg-gray-700"
                   }`}
                 >
                   <Filter size={16} />
@@ -256,7 +255,9 @@ export default function SearchPage() {
                 </button>
 
                 <div className="flex items-center gap-2">
-                  <label className="text-sm font-medium text-gray-700 dark:text-slate-300">Sort:</label>
+                  <label className="text-sm font-medium text-gray-700 dark:text-slate-300">
+                    Sort:
+                  </label>
                   <select
                     value={sort}
                     onChange={(e) => setSort(e.target.value)}
@@ -277,7 +278,7 @@ export default function SearchPage() {
                     onClick={() => setShowMap(!showMap)}
                     className="px-3 py-2 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 dark:bg-gray-800 dark:text-slate-300 dark:hover:bg-gray-700"
                   >
-                    {showMap ? 'Hide Map' : 'Show Map'}
+                    {showMap ? "Hide Map" : "Show Map"}
                   </button>
                   <button
                     onClick={exportResults}
@@ -295,10 +296,12 @@ export default function SearchPage() {
               <Panel>
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">Type</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+                      Type
+                    </label>
                     <select
                       value={filters.type}
-                      onChange={(e) => setFilters(prev => ({ ...prev, type: e.target.value }))}
+                      onChange={(e) => setFilters((prev) => ({ ...prev, type: e.target.value }))}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                     >
                       {RESULT_TYPES.map((type) => (
@@ -308,12 +311,16 @@ export default function SearchPage() {
                       ))}
                     </select>
                   </div>
-                  
+
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">Date Range</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+                      Date Range
+                    </label>
                     <select
                       value={filters.dateRange}
-                      onChange={(e) => setFilters(prev => ({ ...prev, dateRange: e.target.value }))}
+                      onChange={(e) =>
+                        setFilters((prev) => ({ ...prev, dateRange: e.target.value }))
+                      }
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                     >
                       <option value="all">All Time</option>
@@ -323,12 +330,14 @@ export default function SearchPage() {
                       <option value="year">This Year</option>
                     </select>
                   </div>
-                  
+
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">Source</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+                      Source
+                    </label>
                     <select
                       value={filters.source}
-                      onChange={(e) => setFilters(prev => ({ ...prev, source: e.target.value }))}
+                      onChange={(e) => setFilters((prev) => ({ ...prev, source: e.target.value }))}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                     >
                       <option value="all">All Sources</option>
@@ -337,19 +346,25 @@ export default function SearchPage() {
                       <option value="graph">Graph</option>
                     </select>
                   </div>
-                  
+
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">Min Score</label>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+                      Min Score
+                    </label>
                     <input
                       type="range"
                       min="0"
                       max="1"
                       step="0.1"
                       value={filters.minScore}
-                      onChange={(e) => setFilters(prev => ({ ...prev, minScore: parseFloat(e.target.value) }))}
+                      onChange={(e) =>
+                        setFilters((prev) => ({ ...prev, minScore: parseFloat(e.target.value) }))
+                      }
                       className="w-full"
                     />
-                    <div className="text-xs text-gray-500 dark:text-slate-400 mt-1">{filters.minScore}</div>
+                    <div className="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                      {filters.minScore}
+                    </div>
                   </div>
                 </div>
               </Panel>
@@ -377,7 +392,9 @@ export default function SearchPage() {
             {!isLoading && query && results.length === 0 && !error && (
               <div className="text-center py-12">
                 <Search size={48} className="mx-auto mb-4 text-gray-400 dark:text-slate-500" />
-                <h3 className="text-lg font-medium text-gray-900 dark:text-slate-100 mb-2">No results found</h3>
+                <h3 className="text-lg font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  No results found
+                </h3>
                 <p className="text-gray-500 dark:text-slate-400">
                   Try adjusting your search terms or filters
                 </p>
@@ -391,12 +408,14 @@ export default function SearchPage() {
                   <p className="text-sm text-gray-600 dark:text-slate-400">
                     {totalResults.toLocaleString()} results found in {searchTime}ms
                   </p>
-                  <DossierButton getPayload={() => ({ 
-                    query, 
-                    entities: [], 
-                    graphSelection: { nodes: [], edges: [] },
-                    searchResults: results
-                  })} />
+                  <DossierButton
+                    getPayload={() => ({
+                      query,
+                      entities: [],
+                      graphSelection: { nodes: [], edges: [] },
+                      searchResults: results,
+                    })}
+                  />
                 </div>
 
                 {/* Results List */}
@@ -411,18 +430,17 @@ export default function SearchPage() {
 
           {/* Sidebar */}
           <div className="space-y-6">
-            
             {/* Result Types */}
             <Panel title="Result Types">
               <div className="space-y-2">
                 {RESULT_TYPES.map((type) => (
                   <button
                     key={type.value}
-                    onClick={() => setFilters(prev => ({ ...prev, type: type.value }))}
+                    onClick={() => setFilters((prev) => ({ ...prev, type: type.value }))}
                     className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
                       filters.type === type.value
-                        ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
-                        : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                        ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
+                        : "hover:bg-gray-100 dark:hover:bg-gray-800"
                     }`}
                   >
                     <div className="flex items-center justify-between">
@@ -452,18 +470,20 @@ export default function SearchPage() {
             {/* Recent Searches */}
             <Panel title="Recent Searches">
               <div className="space-y-2">
-                {['financial networks', 'ACME Corporation', 'risk analysis'].map((search, index) => (
-                  <button
-                    key={index}
-                    onClick={() => selectSuggestion(search)}
-                    className="w-full text-left px-3 py-2 text-sm text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Clock size={14} />
-                      {search}
-                    </div>
-                  </button>
-                ))}
+                {["financial networks", "ACME Corporation", "risk analysis"].map(
+                  (search, index) => (
+                    <button
+                      key={index}
+                      onClick={() => selectSuggestion(search)}
+                      className="w-full text-left px-3 py-2 text-sm text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Clock size={14} />
+                        {search}
+                      </div>
+                    </button>
+                  ),
+                )}
               </div>
             </Panel>
           </div>
@@ -483,10 +503,14 @@ export default function SearchPage() {
 function SearchResultCard({ result }: { result: SearchResult }) {
   const getResultIcon = (type?: string) => {
     switch (type) {
-      case 'document': return FileText;
-      case 'entity': return Users;
-      case 'location': return MapPin;
-      default: return FileText;
+      case "document":
+        return FileText;
+      case "entity":
+        return Users;
+      case "location":
+        return MapPin;
+      default:
+        return FileText;
     }
   };
 
@@ -498,20 +522,20 @@ function SearchResultCard({ result }: { result: SearchResult }) {
         <div className="p-2 bg-gray-100 dark:bg-gray-800 rounded-lg">
           <Icon size={20} className="text-gray-600 dark:text-slate-400" />
         </div>
-        
+
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between">
             <div className="flex-1">
               <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-1">
                 {result.title || result.id}
               </h3>
-              
+
               {result.snippet && (
                 <p className="text-gray-600 dark:text-slate-400 text-sm mb-2 leading-relaxed">
                   {result.snippet}
                 </p>
               )}
-              
+
               <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-slate-400">
                 {result.score !== undefined && (
                   <div className="flex items-center gap-1">
@@ -551,7 +575,7 @@ function SearchResultCard({ result }: { result: SearchResult }) {
                 </div>
               )}
             </div>
-            
+
             <div className="flex items-center gap-2">
               <button className="p-1 text-gray-400 hover:text-gray-600 rounded">
                 <Eye size={16} />

--- a/apps/frontend/src/lib/url.ts
+++ b/apps/frontend/src/lib/url.ts
@@ -1,0 +1,41 @@
+export type ParamPrimitive = string | number | boolean | null | undefined | Date;
+export type ParamValue = ParamPrimitive | ParamPrimitive[];
+
+/**
+ * Convert heterogenous values into URLSearchParams.
+ * - undefined/null/"" are skipped
+ * - boolean/number/Date are converted to strings
+ * - arrays yield multiple entries
+ */
+export function toSearchParams(input: Record<string, ParamValue>): URLSearchParams {
+  const params = new URLSearchParams();
+
+  const append = (k: string, v: ParamPrimitive) => {
+    if (v === undefined || v === null) return;
+    if (v instanceof Date) {
+      params.append(k, v.toISOString());
+      return;
+    }
+    const s = String(v);
+    if (s.length === 0) return;
+    params.append(k, s);
+  };
+
+  for (const [k, v] of Object.entries(input)) {
+    if (Array.isArray(v)) {
+      if (v.length === 0) continue;
+      for (const item of v) append(k, item);
+    } else {
+      append(k, v as ParamPrimitive);
+    }
+  }
+
+  return params;
+}
+
+/** Helper for building router links: returns "?a=b" or "" */
+export function toQueryString(input: Record<string, ParamValue>): string {
+  const sp = toSearchParams(input);
+  const qs = sp.toString();
+  return qs ? `?${qs}` : "";
+}

--- a/apps/frontend/tests/url.spec.ts
+++ b/apps/frontend/tests/url.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { toSearchParams, toQueryString } from "@/lib/url";
+
+describe("toSearchParams", () => {
+  it("serializes primitives & arrays and filters empty", () => {
+    const sp = toSearchParams({
+      a: "x",
+      b: 1,
+      c: true,
+      d: new Date("2025-01-02T03:04:05Z"),
+      e: ["u", "v"],
+      f: undefined,
+      g: null,
+      h: "",
+    });
+    const s = sp.toString();
+    expect(s).toContain("a=x");
+    expect(s).toContain("b=1");
+    expect(s).toContain("c=true");
+    expect(s).toContain("d=2025-01-02T03%3A04%3A05.000Z");
+    expect(s).toContain("e=u");
+    expect(s).toContain("e=v");
+    expect(s).not.toContain("f=");
+    expect(s).not.toContain("g=");
+    expect(s).not.toContain("h=");
+  });
+
+  it("toQueryString returns leading question mark or empty", () => {
+    expect(toQueryString({})).toBe("");
+    expect(toQueryString({ a: 1 })).toBe("?a=1");
+  });
+});


### PR DESCRIPTION
## Summary
- add `toSearchParams` and `toQueryString` helpers for safe query serialization
- use helper in search page and add lint guard
- cover utility with unit tests

## Testing
- `pnpm -w -F @infoterminal/frontend lint` *(fails: Code style issues found in 150 files)*
- `pnpm -w -F @infoterminal/frontend test` *(fails: 3 failed, 46 passed)*
- `pnpm -w -F @infoterminal/frontend build` *(fails: ESLint must be installed; type error in pages/settings.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c68b2beb308324b7c8e6f430fc4780