### PR TITLE
chore: deduplicate plugin invocation path and deprecate legacy nlp-service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Deprecation window for legacy routes (ISO8601, e.g. 2025-10-31)
+IT_DEPRECATION_CUTOFF_DATE=2025-10-31
+
 # Web / Frontend
 NEXT_PUBLIC_SEARCH_URL=http://localhost:8001
 NEXT_PUBLIC_GRAPH_URL=http://localhost:8002

--- a/.github/workflows/guard-invocation-path.yml
+++ b/.github/workflows/guard-invocation-path.yml
@@ -1,0 +1,19 @@
+name: guard-invocation-path
+on: [push, pull_request]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with: { version: 9 }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -w -C apps/frontend lint
+      - name: Block direct provider hosts in frontend
+        run: |
+          set -e
+          BAD=$(grep -RInE "http(s)?://localhost:(3417|8800)|flowise-connector|openbb-connector" apps/frontend || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Direct provider host references detected:\n$BAD"
+            exit 1
+          fi

--- a/Checkliste.md
+++ b/Checkliste.md
@@ -22,4 +22,9 @@ Kurzanleitung für ein lokales End-to-End Setup von InfoTerminal (MVP).
 5. **Optional: dbt Modelle ausführen**
    - `make dbt-all`
 
+6. **Legacy NLP prüfen**
+   - Sucht/ersetzt alte nlp-service Aufrufe
+   - Frontend Tool-Calls → /api/plugins
+   - grep direkte Hosts
+
 Weitere Details siehe [TODO-Index](docs/dev/roadmap/TODO-Index.md).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ it fe test    # Vitest (dot reporter)
 - **search-api (OpenSearch)**: Volltext, Embeddings, Ranking
 - **graph-api (Neo4j)**: Entitäten, Relationen, Algorithmen
 - **graph-views (Postgres)**: SQL-Views für BI (Superset, Grafana)
-- **nlp-verif (FastAPI)**: NER, Relation Extraction, Summarization, RTE
+- **doc-entities (FastAPI)**: NER, Relation Extraction, Summarization (replaces legacy `nlp-service`)
 
 ### 3. **Verification-Layer**
 

--- a/WORK-ON-new_docs/docs_migration_report.txt
+++ b/WORK-ON-new_docs/docs_migration_report.txt
@@ -107,3 +107,6 @@
 [OK] Userdoc rename: /mnt/data/InfoTerminal-docs-clean/docs/user/7.CLI-Handbuch.md -> /mnt/data/InfoTerminal-docs-clean/docs/user/07-cli-handbuch.md
 [OK] Userdoc rename: /mnt/data/InfoTerminal-docs-clean/docs/user/4.Kernfunktionen.md -> /mnt/data/InfoTerminal-docs-clean/docs/user/04-kernfunktionen.md
 [OK] Userdoc rename: /mnt/data/InfoTerminal-docs-clean/docs/user/1.Einführung.md -> /mnt/data/InfoTerminal-docs-clean/docs/user/01-einfuehrung.md
+[TODO] Frontend Tool-Calls → /api/plugins
+[TODO] grep direkte Hosts
+[TODO] Legacy NLP prüfen

--- a/apps/frontend/.eslintrc.json
+++ b/apps/frontend/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "plugins": ["local-rules"],
   "rules": {
     "no-restricted-syntax": [
       "warn",
@@ -6,6 +7,7 @@
         "selector": "NewExpression[callee.name='URLSearchParams'] ObjectExpression",
         "message": "Use toSearchParams(...) instead of direct object initialization."
       }
-    ]
+    ],
+    "local-rules/no-direct-host-fetch": "error"
   }
 }

--- a/apps/frontend/eslint-local-rules.js
+++ b/apps/frontend/eslint-local-rules.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'no-direct-host-fetch': require('../../tools/eslint-rules/no-direct-host-fetch.js')
+};

--- a/apps/frontend/lib/plugins.ts
+++ b/apps/frontend/lib/plugins.ts
@@ -1,0 +1,14 @@
+export async function invokeTool(plugin: string, tool: string, payload: any, init?: RequestInit) {
+  const res = await fetch(`/api/plugins/invoke/${plugin}/${tool}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+export async function listTools() {
+  const res = await fetch(`/api/plugins/tools`);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -41,11 +41,15 @@
     "tailwindcss": "^4.1.12",
     "typescript": "^5.9.2",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^1.6.1"
+    "vitest": "^1.6.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-local-rules": "^3.0.2"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": "prettier --write"
   },
+  "eslintConfig": { "plugins": ["local-rules"] },
+  "eslintConfigLocalRules": { "no-direct-host-fetch": "../../tools/eslint-rules/no-direct-host-fetch.js" },
   "name": "@infoterminal/frontend",
   "private": true,
   "scripts": {
@@ -54,7 +58,7 @@
     "dev": "next dev -p 3411",
     "e2e": "playwright test",
     "e2e:install": "npx playwright install --with-deps",
-    "lint": "prettier -c \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",
+    "lint": "prettier -c \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\" && next lint",
     "prebuild": "bash ../../scripts/tailwind_v4_guard.sh",
     "predev": "bash ../../scripts/tailwind_v4_guard.sh",
     "prepare": "husky",

--- a/apps/frontend/pages/plugins/index.tsx
+++ b/apps/frontend/pages/plugins/index.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState, useMemo } from 'react';
+import { invokeTool } from '../../lib/plugins';
 import Link from 'next/link';
-import { 
-  Puzzle, 
-  Search, 
-  Filter, 
-  Plus, 
-  Settings, 
-  Play, 
-  CheckCircle, 
-  XCircle, 
+import {
+  Puzzle,
+  Search,
+  Filter,
+  Plus,
+  Settings,
+  Play,
+  CheckCircle,
+  XCircle,
   AlertTriangle,
   Clock,
   Download,
@@ -33,7 +34,7 @@ interface PluginItem {
   provider?: string;
   description?: string;
   category?: string;
-  capabilities?: { 
+  capabilities?: {
     tools?: any[];
     permissions?: string[];
     dependencies?: string[];
@@ -137,7 +138,7 @@ function PluginCard({
   return (
     <Panel className="hover:shadow-md transition-shadow">
       <div className="space-y-4">
-        
+
         {/* Plugin Header */}
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
@@ -155,7 +156,7 @@ function PluginCard({
               </p>
             </div>
           </div>
-          
+
           <div className="flex items-center gap-2">
             <button
               onClick={onRefreshHealth}
@@ -225,7 +226,7 @@ function PluginCard({
                   disabled={isUpdating}
                   className="sr-only"
                 />
-                <div 
+                <div
                   onClick={() => !isUpdating && handleToggle(!enabled)}
                   className={`w-11 h-6 rounded-full cursor-pointer transition-colors ${
                     enabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-gray-700'
@@ -240,7 +241,7 @@ function PluginCard({
                 {enabled ? 'Enabled' : 'Disabled'}
               </span>
             </div>
-            
+
             {isAdmin && (
               <select
                 value={scope}
@@ -252,7 +253,7 @@ function PluginCard({
               </select>
             )}
           </div>
-          
+
           <div className="flex items-center gap-2">
             <button
               onClick={onQuickTest}
@@ -261,7 +262,7 @@ function PluginCard({
               <Play size={12} />
               Test
             </button>
-            
+
             <button
               onClick={() => onConfig(scope)}
               className="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 dark:bg-gray-800 dark:text-slate-300 dark:hover:bg-gray-700"
@@ -269,7 +270,7 @@ function PluginCard({
               <Settings size={12} />
               Config
             </button>
-            
+
             <Link
               href={`/plugins/${plugin.name}`}
               className="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-primary-700 bg-primary-100 rounded-lg hover:bg-primary-200 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
@@ -291,7 +292,7 @@ export default function PluginsPage() {
   const [health, setHealth] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  
+
   const [filters, setFilters] = useState<PluginFilter>({
     search: '',
     category: 'all',
@@ -378,7 +379,7 @@ export default function PluginsPage() {
       }));
 
       setItems(merged);
-      
+
       // Load health for all plugins
       await refreshAllHealth(merged);
     } catch (error) {
@@ -429,7 +430,7 @@ export default function PluginsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled, scope }),
       });
-      
+
       setItems(prev => prev.map(p => p.name === name ? { ...p, enabled } : p));
     } catch (error) {
       console.error('Failed to toggle plugin:', error);
@@ -439,9 +440,9 @@ export default function PluginsPage() {
   const openConfig = async (plugin: PluginItem, scope: 'user' | 'global') => {
     const current = plugin.config || {};
     const text = prompt('Plugin Configuration (JSON):', JSON.stringify(current, null, 2));
-    
+
     if (!text) return;
-    
+
     try {
       const config = JSON.parse(text);
       await fetch(`/api/plugins/${plugin.name}/config`, {
@@ -449,9 +450,9 @@ export default function PluginsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ config, scope }),
       });
-      
+
       // Update local state
-      setItems(prev => prev.map(p => 
+      setItems(prev => prev.map(p =>
         p.name === plugin.name ? { ...p, config } : p
       ));
     } catch {
@@ -462,10 +463,10 @@ export default function PluginsPage() {
   const quickTest = async (plugin: PluginItem) => {
     const tool = prompt('Tool name:');
     if (!tool) return;
-    
+
     let payload: any = {};
     const payloadText = prompt('JSON payload:', '{}');
-    
+
     if (payloadText) {
       try {
         payload = JSON.parse(payloadText);
@@ -474,15 +475,9 @@ export default function PluginsPage() {
         return;
       }
     }
-    
+
     try {
-      const response = await fetch(`/api/plugins/invoke/${plugin.name}/${tool}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      
-      const result = await response.json();
+      const result = await invokeTool(plugin.name, tool, payload);
       alert(`Result:\n${JSON.stringify(result, null, 2)}`);
     } catch (error) {
       alert(`Test failed: ${error}`);
@@ -525,7 +520,7 @@ export default function PluginsPage() {
   return (
     <DashboardLayout title="Plugin Marketplace" subtitle="Extend your platform with powerful integrations">
       <div className="max-w-7xl mx-auto space-y-6">
-        
+
         {/* Stats Overview */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-900/30">
@@ -537,7 +532,7 @@ export default function PluginsPage() {
               <Puzzle size={24} className="text-blue-500" />
             </div>
           </div>
-          
+
           <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-900/30">
             <div className="flex items-center justify-between">
               <div>
@@ -547,7 +542,7 @@ export default function PluginsPage() {
               <CheckCircle size={24} className="text-green-500" />
             </div>
           </div>
-          
+
           <div className="p-4 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-900/30">
             <div className="flex items-center justify-between">
               <div>
@@ -557,7 +552,7 @@ export default function PluginsPage() {
               <Server size={24} className="text-purple-500" />
             </div>
           </div>
-          
+
           <div className="p-4 bg-orange-50 dark:bg-orange-900/20 rounded-lg border border-orange-200 dark:border-orange-900/30">
             <div className="flex items-center justify-between">
               <div>
@@ -584,7 +579,7 @@ export default function PluginsPage() {
                 className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
               />
             </div>
-            
+
             <select
               value={filters.category}
               onChange={(e) => setFilters(prev => ({ ...prev, category: e.target.value }))}
@@ -594,7 +589,7 @@ export default function PluginsPage() {
                 <option key={category.value} value={category.value}>{category.label}</option>
               ))}
             </select>
-            
+
             <select
               value={filters.status}
               onChange={(e) => setFilters(prev => ({ ...prev, status: e.target.value }))}
@@ -605,7 +600,7 @@ export default function PluginsPage() {
               ))}
             </select>
           </div>
-          
+
           <div className="flex items-center gap-2">
             <button
               onClick={() => refreshAllHealth()}
@@ -615,7 +610,7 @@ export default function PluginsPage() {
               <RefreshCw size={14} className={refreshing ? 'animate-spin' : ''} />
               Refresh
             </button>
-            
+
             <button
               onClick={exportConfig}
               className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 dark:bg-gray-800 dark:text-slate-300 dark:hover:bg-gray-700"
@@ -623,7 +618,7 @@ export default function PluginsPage() {
               <Download size={14} />
               Export
             </button>
-            
+
             <button className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700">
               <Plus size={14} />
               Add Plugin
@@ -632,7 +627,7 @@ export default function PluginsPage() {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          
+
           {/* Main Content */}
           <div className="lg:col-span-3">
             <div className="space-y-4">
@@ -641,7 +636,7 @@ export default function PluginsPage() {
                   Showing {filteredPlugins.length} of {items.length} plugins
                 </p>
               </div>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 {filteredPlugins.map((plugin) => (
                   <PluginCard
@@ -655,7 +650,7 @@ export default function PluginsPage() {
                     onRefreshHealth={() => refreshPluginHealth(plugin.name)}
                   />
                 ))}
-                
+
                 {filteredPlugins.length === 0 && (
                   <div className="col-span-2 text-center py-12">
                     <Puzzle size={48} className="mx-auto text-gray-400 dark:text-slate-500 mb-4" />
@@ -676,20 +671,20 @@ export default function PluginsPage() {
 
           {/* Sidebar */}
           <div className="space-y-6">
-            
+
             {/* Categories */}
             <Panel title="Categories">
               <div className="space-y-2">
                 {PLUGIN_CATEGORIES.filter(c => c.value !== 'all').map((category) => {
                   const count = pluginStats.categories[category.value] || 0;
                   const Icon = category.icon;
-                  
+
                   return (
                     <button
                       key={category.value}
-                      onClick={() => setFilters(prev => ({ 
-                        ...prev, 
-                        category: category.value === filters.category ? 'all' : category.value 
+                      onClick={() => setFilters(prev => ({
+                        ...prev,
+                        category: category.value === filters.category ? 'all' : category.value
                       }))}
                       className={`w-full flex items-center justify-between p-3 rounded-lg transition-colors ${
                         filters.category === category.value
@@ -722,7 +717,7 @@ export default function PluginsPage() {
                     </div>
                   </div>
                 </button>
-                
+
                 <button className="w-full text-left p-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                   <div className="flex items-center gap-3">
                     <Zap size={16} className="text-green-500" />
@@ -732,7 +727,7 @@ export default function PluginsPage() {
                     </div>
                   </div>
                 </button>
-                
+
                 <button className="w-full text-left p-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                   <div className="flex items-center gap-3">
                     <BarChart3 size={16} className="text-purple-500" />
@@ -751,7 +746,7 @@ export default function PluginsPage() {
                 {Object.entries(['up', 'down', 'degraded', 'unknown']).map(([_, status]) => {
                   const count = Object.values(health).filter(h => h === status).length;
                   if (count === 0) return null;
-                  
+
                   return (
                     <div key={status} className="flex items-center justify-between text-sm">
                       <div className="flex items-center gap-2">

--- a/apps/frontend/src/__tests__/no-direct-host-fetch.spec.ts
+++ b/apps/frontend/src/__tests__/no-direct-host-fetch.spec.ts
@@ -1,0 +1,9 @@
+import { ESLint } from 'eslint';
+import path from 'path';
+import { expect, test } from 'vitest';
+
+test('no direct host fetch rule triggers', async () => {
+  const eslint = new ESLint({ useEslintrc: true, cwd: path.join(__dirname, '..') });
+  const results = await eslint.lintText("fetch('http://localhost:1234')\n");
+  expect(results[0].errorCount).toBeGreaterThan(0);
+});

--- a/docs/dev/en/architecture/adr/ADR-0004-single-invocation-path.md
+++ b/docs/dev/en/architecture/adr/ADR-0004-single-invocation-path.md
@@ -1,0 +1,7 @@
+# ADR-0004: Single Invocation Path for Tools
+
+- **Decision**: All user-facing tool invocations MUST go through `agent-connector /plugins` (`/plugins/tools`, `/plugins/invoke/{plugin}/{tool}`).
+- **Rationale**: Avoid duplicate code paths, centralize auth/tenant/audit, enable plugin registry & policy.
+- **Scope**: Frontend, other services (no direct calls to flowise/openbb/etc).
+- **Migration**: old routes receive 308 until IT_DEPRECATION_CUTOFF_DATE, then 410.
+- **Guards**: ESLint custom rule + CI grep.

--- a/docs/dev/en/migration/2025-plugins-invocation-path.md
+++ b/docs/dev/en/migration/2025-plugins-invocation-path.md
@@ -1,0 +1,7 @@
+# Migration: Single Plugin Invocation Path (2025)
+
+- Write manifests for flowise, openbb, n8n.
+- Refactor frontend tool calls to use `/api/plugins`.
+- Add ESLint rule and CI guard against direct provider hosts.
+- Deprecate `nlp-service` routes via gateway redirect/410 policy.
+- Rollback: restore removed routes and disable rule if needed.

--- a/docs/dev/en/nlp/README.md
+++ b/docs/dev/en/nlp/README.md
@@ -1,6 +1,6 @@
-# NLP Service
+# NLP Service (Legacy)
 
-Provides basic NLP features for documents.
+This service is deprecated. Use `doc-entities` for active NLP features.
 
 ## Endpoints
 - `POST /ner` — spaCy NER with models selected via environment variables.

--- a/plugins/n8n/mapping.json
+++ b/plugins/n8n/mapping.json
@@ -1,0 +1,4 @@
+{
+  "workflow.investigate_person": { "mode": "webhook", "webhookPath": "/webhook/investigate-person", "method": "POST" },
+  "workflow.financial_risk_assistant": { "mode": "rest", "workflowId": "FRA-123" }
+}

--- a/plugins/n8n/plugin.yaml
+++ b/plugins/n8n/plugin.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+name: n8n
+version: 0.1.0
+provider: n8n
+capabilities:
+  tools:
+    - name: workflow.investigate_person
+      description: Search→Graph→NER via n8n
+      argsSchema:
+        type: object
+        properties: { q: { type: string } }
+        required: [q]
+      timeoutMs: 30000
+    - name: workflow.financial_risk_assistant
+      description: FRA workflow
+      argsSchema:
+        type: object
+        properties: { accountId: { type: string }, period: { type: string } }
+        required: [accountId]
+      timeoutMs: 60000
+endpoints:
+  baseUrl: ${N8N_BASE_URL:-http://localhost:5678}
+  health: healthz

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,12 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-plugin-local-rules:
+        specifier: ^3.0.2
+        version: 3.0.2
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -172,6 +178,8 @@ importers:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@24.3.0)(jsdom@24.1.3)(lightningcss@1.30.1)
+
+  packages/plugin-sdk: {}
 
   services/gateway:
     dependencies:
@@ -407,6 +415,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -439,6 +465,19 @@ packages:
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
+
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -979,6 +1018,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
   '@vitest/coverage-v8@1.6.1':
     resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
     peerDependencies:
@@ -1003,6 +1045,11 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -1015,6 +1062,9 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1128,12 +1178,20 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1341,6 +1399,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
@@ -1374,6 +1435,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -1467,15 +1532,48 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-plugin-local-rules@3.0.2:
+    resolution: {integrity: sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==}
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -1512,12 +1610,25 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1526,6 +1637,17 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -1598,6 +1720,10 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
@@ -1606,6 +1732,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
 
   globby@14.0.2:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
@@ -1620,6 +1750,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1702,6 +1835,14 @@ packages:
   immer@10.1.3:
     resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
 
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -1764,6 +1905,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
 
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -1836,6 +1981,15 @@ packages:
       canvas:
         optional: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
@@ -1847,8 +2001,15 @@ packages:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -1923,6 +2084,10 @@ packages:
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
@@ -2187,6 +2352,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   needle@3.3.1:
     resolution: {integrity: sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==}
     engines: {node: '>= 4.4.x'}
@@ -2314,9 +2482,21 @@ packages:
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -2328,6 +2508,10 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -2344,6 +2528,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -2423,6 +2611,10 @@ packages:
 
   preact@10.27.1:
     resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2573,9 +2765,18 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rollup@4.50.1:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
@@ -2778,6 +2979,9 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -2824,9 +3028,17 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -2870,6 +3082,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -3006,6 +3221,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3046,6 +3265,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yocto-queue@1.2.1:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
@@ -3182,6 +3405,29 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.1': {}
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -3220,6 +3466,18 @@ snapshots:
   '@heroicons/react@2.2.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.1
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -3682,6 +3940,8 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@ungap/structured-clone@1.3.0': {}
+
   '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@24.3.0)(jsdom@24.1.3)(lightningcss@1.30.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -3735,6 +3995,10 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
@@ -3742,6 +4006,13 @@ snapshots:
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
@@ -3854,6 +4125,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001741: {}
 
   chai@4.5.0:
@@ -3865,6 +4138,11 @@ snapshots:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.1.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
@@ -4042,6 +4320,8 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  deep-is@0.1.4: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -4068,6 +4348,10 @@ snapshots:
       wrappy: 1.0.2
 
   diff-sequences@29.6.3: {}
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -4172,6 +4456,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@4.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -4180,7 +4466,73 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-plugin-local-rules@3.0.2: {}
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint@8.57.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.1
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 3.4.3
+
   esprima@4.0.1: {}
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
 
   estraverse@5.3.0: {}
 
@@ -4248,6 +4600,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4256,9 +4610,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
 
   fill-range@7.1.1:
     dependencies:
@@ -4275,6 +4637,19 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+      rimraf: 3.0.2
+
+  flatted@3.3.3: {}
 
   follow-redirects@1.15.11(debug@4.4.1):
     optionalDependencies:
@@ -4349,6 +4724,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob@11.0.3:
     dependencies:
       foreground-child: 3.3.1
@@ -4367,6 +4746,10 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
   globby@14.0.2:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -4381,6 +4764,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
 
@@ -4472,6 +4857,13 @@ snapshots:
 
   immer@10.1.3: {}
 
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
   indent-string@4.0.0: {}
 
   inflight@1.0.6:
@@ -4513,6 +4905,8 @@ snapshots:
   is-hexadecimal@2.0.1: {}
 
   is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
 
   is-plain-object@5.0.0: {}
 
@@ -4603,6 +4997,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   jsonc-parser@3.3.1: {}
 
   jsonpointer@5.0.1: {}
@@ -4611,7 +5011,16 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   leaflet@1.9.4: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -4676,6 +5085,10 @@ snapshots:
     dependencies:
       mlly: 1.8.0
       pkg-types: 1.3.1
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.castarray@4.4.0: {}
 
@@ -5046,6 +5459,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  natural-compare@1.4.0: {}
+
   needle@3.3.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -5159,9 +5574,26 @@ snapshots:
       object-hash: 2.2.0
       oidc-token-hash: 5.1.1
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.1
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -5182,6 +5614,10 @@ snapshots:
       netmask: 2.0.2
 
   package-json-from-dist@1.0.1: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -5207,6 +5643,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -5279,6 +5717,8 @@ snapshots:
       pretty-format: 3.8.0
 
   preact@10.27.1: {}
+
+  prelude-ls@1.2.1: {}
 
   prettier@3.6.2: {}
 
@@ -5439,7 +5879,13 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  resolve-from@4.0.0: {}
+
   reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
 
   rollup@4.50.1:
     dependencies:
@@ -5670,6 +6116,8 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  text-table@0.2.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -5703,7 +6151,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-detect@4.1.0: {}
+
+  type-fest@0.20.2: {}
 
   type-is@1.6.18:
     dependencies:
@@ -5733,6 +6187,10 @@ snapshots:
       browserslist: 4.25.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-parse@1.5.10:
     dependencies:
@@ -5877,6 +6335,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5907,5 +6367,7 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}

--- a/services/gateway/tests/test_legacy_nlp.py
+++ b/services/gateway/tests/test_legacy_nlp.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+from pathlib import Path
+
+from httpx import AsyncClient, ASGITransport
+
+
+async def test_legacy_nlp_redirect(monkeypatch):
+    monkeypatch.setenv("IT_DEPRECATION_CUTOFF_DATE", "2999-01-01")
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from app import app as app_module
+
+    app_module = importlib.reload(app_module)
+    app = app_module.app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/nlp-service/ner")
+        assert r.status_code == 308
+        assert r.headers["location"] == "/doc-entities/ner"
+
+
+async def test_legacy_nlp_gone(monkeypatch):
+    monkeypatch.setenv("IT_DEPRECATION_CUTOFF_DATE", "2000-01-01")
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from app import app as app_module
+
+    app_module = importlib.reload(app_module)
+    app = app_module.app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        r = await ac.get("/nlp-service/ner")
+        assert r.status_code == 410
+        assert r.json()["hint"] == "use /doc-entities"

--- a/services/nlp-service/README_LEGACY.md
+++ b/services/nlp-service/README_LEGACY.md
@@ -1,0 +1,3 @@
+# Legacy NLP Service
+
+This service is deprecated. Use `services/doc-entities` instead for NLP features.

--- a/tools/eslint-rules/no-direct-host-fetch.js
+++ b/tools/eslint-rules/no-direct-host-fetch.js
@@ -1,0 +1,14 @@
+module.exports = {
+  meta: { type: "problem", docs: { description: "Disallow direct host URLs in fetch; use /api/plugins instead" } },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.name !== "fetch") return;
+        const arg = node.arguments[0];
+        if (arg && arg.type === "Literal" && typeof arg.value === "string" && /^https?:\/\//i.test(arg.value)) {
+          context.report({ node: arg, message: "Do not hardcode hosts in fetch(). Use relative /api/plugins or API utils." });
+        }
+      }
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add IT_DEPRECATION_CUTOFF_DATE env and mark nlp-service as legacy
- redirect legacy /nlp-service routes to /doc-entities until cutoff then 410
- route frontend tools via unified /api/plugins with lint & CI guards
- document single invocation path and migration steps

## Testing
- `pre-commit run --files .env.example services/nlp-service/README_LEGACY.md services/gateway/app/app.py README.md docs/dev/en/nlp/README.md Checkliste.md plugins/n8n/plugin.yaml plugins/n8n/mapping.json apps/frontend/lib/plugins.ts apps/frontend/pages/plugins/index.tsx apps/frontend/pages/plugins/[name].tsx tools/eslint-rules/no-direct-host-fetch.js apps/frontend/.eslintrc.json apps/frontend/package.json .github/workflows/guard-invocation-path.yml docs/dev/en/architecture/adr/ADR-0004-single-invocation-path.md services/gateway/tests/test_legacy_nlp.py apps/frontend/eslint-local-rules.js apps/frontend/src/__tests__/no-direct-host-fetch.spec.ts Checkliste.md WORK-ON-new_docs/docs_migration_report.txt docs/dev/en/migration/2025-plugins-invocation-path.md`
- `pytest services/gateway/tests/test_legacy_nlp.py --cov=app --cov-report=term-missing --cov-fail-under=0`
- `pnpm -C apps/frontend test src/__tests__/no-direct-host-fetch.spec.ts`
- `pnpm -C apps/frontend lint` *(fails: Code style issues found in 156 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6958b2ea88324bdd9de7e86b30c86