### PR TITLE
feat: gateway security and ops improvements

### DIFF
--- a/.env.dev.ports
+++ b/.env.dev.ports
@@ -15,6 +15,8 @@ IT_AUTH_REQUIRED=0
 IT_OIDC_ISSUER=http://localhost:8080/realms/infoterminal
 IT_OIDC_AUDIENCE=infoterminal
 IT_OIDC_JWKS_URL=http://localhost:8080/realms/infoterminal/protocol/openid-connect/certs
+IT_OIDC_SKEW=60
+OPA_URL=http://localhost:8181/v1/data/access/allow
 
 # Observability (opt-in)
 IT_ENABLE_METRICS=0

--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,8 @@ IT_AUTH_REQUIRED=0
 IT_OIDC_ISSUER=http://localhost:8080/realms/infoterminal
 IT_OIDC_AUDIENCE=infoterminal
 IT_OIDC_JWKS_URL=http://localhost:8080/realms/infoterminal/protocol/openid-connect/certs
+IT_OIDC_SKEW=60
+OPA_URL=http://localhost:8181/v1/data/access/allow
 
 # Observability (opt-in)
 IT_ENABLE_METRICS=0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,3 +8,6 @@ gitleaks protect --staged --redact --config .gitleaks.toml
 ```
 
 - Optional: install the pre-commit hook to run gitleaks automatically before each commit.
+- Gateway enforces OIDC JWTs (`iss`, `aud`, JWKS cache, clock skew via `IT_OIDC_SKEW`) and calls OPA for sensitive paths.
+- Security relevant actions emit structured entries via `audit_log`.
+- Backup and recovery scripts live under `scripts/` with `DRY_RUN` support; see runbook in `docs/runbooks/`.

--- a/docs/runbooks/backup-recovery.de.md
+++ b/docs/runbooks/backup-recovery.de.md
@@ -1,0 +1,17 @@
+# Backup und Wiederherstellung
+
+Skripte erzeugen zeitgestempelte Backups für Neo4j, OpenSearch und Postgres.
+
+## Backup
+```
+DRY_RUN=1 scripts/backup_neo4j.sh
+DRY_RUN=1 scripts/backup_opensearch.sh
+DRY_RUN=1 scripts/backup_postgres.sh
+```
+
+## Restore
+```
+DRY_RUN=1 scripts/restore_neo4j.sh backups/neo4j_<ts>.dump
+DRY_RUN=1 scripts/restore_opensearch.sh <snapshot_id>
+DRY_RUN=1 scripts/restore_postgres.sh backups/postgres_<ts>.sql
+```

--- a/docs/runbooks/backup-recovery.en.md
+++ b/docs/runbooks/backup-recovery.en.md
@@ -1,0 +1,17 @@
+# Backup and Recovery
+
+These scripts create timestamped backups for Neo4j, OpenSearch and Postgres.
+
+## Backup
+```
+DRY_RUN=1 scripts/backup_neo4j.sh
+DRY_RUN=1 scripts/backup_opensearch.sh
+DRY_RUN=1 scripts/backup_postgres.sh
+```
+
+## Restore
+```
+DRY_RUN=1 scripts/restore_neo4j.sh backups/neo4j_<ts>.dump
+DRY_RUN=1 scripts/restore_opensearch.sh <snapshot_id>
+DRY_RUN=1 scripts/restore_postgres.sh backups/postgres_<ts>.sql
+```

--- a/observability/dashboards/gateway_opa.json
+++ b/observability/dashboards/gateway_opa.json
@@ -11,7 +11,7 @@
       "gridPos": {"x":0,"y":0,"w":8,"h":6},
       "targets": [
         {
-          "expr": "sum(rate(http_request_duration_seconds_count[1m]))",
+          "expr": "sum(rate(gateway_request_duration_seconds_count[1m]))",
           "legendFormat": "qps"
         }
       ]
@@ -23,8 +23,8 @@
       "lines": true,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le,route) (rate(http_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "{{route}}"
+          "expr": "histogram_quantile(0.95, sum by (le,path) (rate(gateway_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{path}}"
         }
       ]
     },
@@ -34,7 +34,7 @@
       "gridPos": {"x":0,"y":6,"w":12,"h":8},
       "targets": [
         {
-          "expr": "sum(rate(http_request_duration_seconds_count{route=~\"/api/.*\",status=\"403\"}[5m])) / sum(rate(http_request_duration_seconds_count{route=~\"/api/.*\"}[5m]))",
+          "expr": "sum(rate(gateway_request_duration_seconds_count{path=~\"/api/.*\",status=\"403\"}[5m])) / sum(rate(gateway_request_duration_seconds_count{path=~\"/api/.*\"}[5m]))",
           "legendFormat": "403 / total"
         }
       ],

--- a/scripts/backup_neo4j.sh
+++ b/scripts/backup_neo4j.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TS=$(date +%Y%m%d_%H%M%S)
+OUT=${1:-backups}
+mkdir -p "$OUT"
+FILE="$OUT/neo4j_$TS.dump"
+CMD="docker exec neo4j neo4j-admin database dump neo4j --to=$FILE"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/scripts/backup_opensearch.sh
+++ b/scripts/backup_opensearch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TS=$(date +%Y%m%d_%H%M%S)
+OUT=${1:-backups}
+mkdir -p "$OUT"
+FILE="$OUT/opensearch_$TS.snapshot"
+CMD="docker exec opensearch bash -c 'curl -XPUT localhost:9200/_snapshot/it_backup/$TS?wait_for_completion=true'"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TS=$(date +%Y%m%d_%H%M%S)
+OUT=${1:-backups}
+mkdir -p "$OUT"
+FILE="$OUT/postgres_$TS.sql"
+CMD="docker exec postgres pg_dump -U postgres --format=plain --file=/tmp/dump.sql && docker cp postgres:/tmp/dump.sql $FILE"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/scripts/restore_neo4j.sh
+++ b/scripts/restore_neo4j.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FILE=${1:?dump file}
+CMD="docker exec neo4j neo4j-admin database load neo4j --from=$FILE --force"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/scripts/restore_opensearch.sh
+++ b/scripts/restore_opensearch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SNAP=${1:?snapshot id}
+CMD="docker exec opensearch bash -c 'curl -XPOST localhost:9200/_snapshot/it_backup/$SNAP/_restore?wait_for_completion=true'"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FILE=${1:?sql file}
+CMD="docker cp $FILE postgres:/tmp/restore.sql && docker exec postgres psql -U postgres -f /tmp/restore.sql"
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN: $CMD"
+else
+  echo "+ $CMD"
+  eval "$CMD"
+fi

--- a/services/_shared/audit.py
+++ b/services/_shared/audit.py
@@ -1,0 +1,17 @@
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict
+
+log = logging.getLogger("audit")
+
+
+def audit_log(action: str, user: str, tenant: str, **extra: Any) -> None:
+    entry: Dict[str, Any] = {
+        "ts": datetime.utcnow().isoformat(),
+        "action": action,
+        "user": user,
+        "tenant": tenant,
+    }
+    entry.update(extra)
+    log.info(json.dumps(entry))

--- a/services/gateway/app/app.py
+++ b/services/gateway/app/app.py
@@ -1,14 +1,55 @@
 import os
+import json
+import time
+import uuid
 from datetime import datetime
+import logging
+import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from .auth import auth_context
+from _shared.audit import audit_log
 
 AUTH_REQUIRED = os.getenv("IT_AUTH_REQUIRED", "0") == "1"
 TENANCY_MODE = os.getenv("IT_TENANCY_MODE", "single")
 TENANT_CLAIM = os.getenv("IT_TENANT_CLAIM", "tenant")
 LEGACY_PREFIXES = ["/nlp-service", "/api/nlp-service"]
 CUTOFF = os.getenv("IT_DEPRECATION_CUTOFF_DATE", "")
+OPA_URL = os.getenv("OPA_URL", "")
+SENSITIVE_PREFIXES = ["/plugins/invoke", "/graph-api/alg"]
+
+REQUEST_COUNT = Counter(
+    "gateway_requests_total",
+    "Total requests",
+    ["method", "path", "status"],
+)
+REQUEST_LATENCY = Histogram(
+    "gateway_request_duration_seconds",
+    "Request latency",
+    ["method", "path", "status"],
+    buckets=[0.1, 0.3, 1, 3, 10],
+)
+
+
+async def opa_check(request: Request) -> bool:
+    if not OPA_URL:
+        return True
+    input_data = {
+        "path": request.url.path,
+        "method": request.method,
+        "user": getattr(request.state, "user_id", "anon"),
+        "tenant": getattr(request.state, "tenant_id", "dev"),
+    }
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.post(OPA_URL, json={"input": input_data})
+            r.raise_for_status()
+            data = r.json()
+            return bool(data.get("result"))
+    except Exception:
+        return False
+
 
 app = FastAPI(title="gateway")
 
@@ -31,6 +72,9 @@ async def oidc_middleware(request: Request, call_next):
     if path in ("/healthz", "/readyz"):
         return await call_next(request)
 
+    rid = request.headers.get("x-request-id") or str(uuid.uuid4())
+    request.state.request_id = rid
+    start = time.time()
     ctx = await auth_context(request)
     if AUTH_REQUIRED and not ctx:
         return Response(status_code=401, content="Unauthorized")
@@ -42,12 +86,44 @@ async def oidc_middleware(request: Request, call_next):
         request.state.claims = claims
     tenant = claims.get(TENANT_CLAIM) if TENANCY_MODE == "multi" else "dev"
     request.state.tenant_id = tenant or "default"
+    if any(path.startswith(p) for p in SENSITIVE_PREFIXES):
+        allowed = await opa_check(request)
+        audit_log(
+            "opa_decision",
+            getattr(request.state, "user_id", "anon"),
+            request.state.tenant_id,
+            path=path,
+            allowed=allowed,
+        )
+        if not allowed:
+            return Response(status_code=403, content="Forbidden")
     resp = await call_next(request)
     resp.headers["X-API-Version"] = "v1"
     resp.headers["X-Tenant-Id"] = request.state.tenant_id
+    resp.headers["X-Request-Id"] = rid
     if ctx:
         resp.headers["X-User-Id"] = request.state.user_id
         resp.headers["X-Scopes"] = " ".join(request.state.scopes)
+    labels = {
+        "method": request.method,
+        "path": request.url.path,
+        "status": str(resp.status_code),
+    }
+    REQUEST_COUNT.labels(**labels).inc()
+    REQUEST_LATENCY.labels(**labels).observe(time.time() - start)
+    logging.getLogger("gateway").info(
+        json.dumps(
+            {
+                "service": "gateway",
+                "request_id": rid,
+                "user": getattr(request.state, "user_id", "anon"),
+                "tenant": request.state.tenant_id,
+                "path": path,
+                "method": request.method,
+                "status": resp.status_code,
+            }
+        )
+    )
     return resp
 
 
@@ -59,3 +135,8 @@ async def healthz():
 @app.get("/readyz")
 async def readyz():
     return {"ok": True}
+
+
+@app.get("/metrics")
+async def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/gateway/app/auth.py
+++ b/services/gateway/app/auth.py
@@ -11,6 +11,7 @@ ISSUER = os.getenv("IT_OIDC_ISSUER", "")
 AUDIENCE = os.getenv("IT_OIDC_AUDIENCE", "")
 JWKS_URL = os.getenv("IT_OIDC_JWKS_URL", "")
 AUTH_REQUIRED = os.getenv("IT_AUTH_REQUIRED", "0") == "1"
+SKEW = int(os.getenv("IT_OIDC_SKEW", "60"))
 
 _JWKS_CACHE: Dict[str, Any] = {"keys": [], "ts": 0}
 _CACHE_TTL = 300
@@ -43,6 +44,7 @@ async def validate_bearer(token: str) -> Optional[Dict[str, Any]]:
             audience=AUDIENCE,
             issuer=ISSUER,
             options={"verify_at_hash": False},
+            leeway=SKEW,
         )
         return claims
     except Exception as e:

--- a/services/gateway/tests/conftest.py
+++ b/services/gateway/tests/conftest.py
@@ -1,3 +1,3 @@
-from fixtures.keys import rsa_keys, valid_token
+from fixtures.keys import rsa_keys, valid_token, expired_token
 
-__all__ = ["rsa_keys", "valid_token"]
+__all__ = ["rsa_keys", "valid_token", "expired_token"]

--- a/services/gateway/tests/fixtures/keys.py
+++ b/services/gateway/tests/fixtures/keys.py
@@ -1,4 +1,5 @@
 import base64
+import time
 from typing import Tuple
 
 import pytest
@@ -15,11 +16,17 @@ def _to_jwk(key: rsa.RSAPrivateKey, kid: str = "test") -> Tuple[str, dict]:
         encryption_algorithm=serialization.NoEncryption(),
     )
     pub = key.public_key().public_numbers()
-    n = base64.urlsafe_b64encode(
-        pub.n.to_bytes((pub.n.bit_length() + 7) // 8, "big")
-    ).rstrip(b"=").decode()
+    n = (
+        base64.urlsafe_b64encode(pub.n.to_bytes((pub.n.bit_length() + 7) // 8, "big"))
+        .rstrip(b"=")
+        .decode()
+    )
     e = base64.urlsafe_b64encode(pub.e.to_bytes(3, "big")).rstrip(b"=").decode()
-    jwks = {"keys": [{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e}]}
+    jwks = {
+        "keys": [
+            {"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e}
+        ]
+    }
     return priv_pem.decode(), jwks
 
 
@@ -34,6 +41,22 @@ def valid_token(rsa_keys):
     priv, _ = rsa_keys
     return jwt.encode(
         {"sub": "user", "aud": "test", "iss": "test-issuer"},
+        priv,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+
+
+@pytest.fixture()
+def expired_token(rsa_keys):
+    priv, _ = rsa_keys
+    return jwt.encode(
+        {
+            "sub": "user",
+            "aud": "test",
+            "iss": "test-issuer",
+            "exp": int(time.time()) - 10,
+        },
         priv,
         algorithm="RS256",
         headers={"kid": "test"},


### PR DESCRIPTION
## Summary
- handle OIDC clock skew and env config
- add OPA authorization with audit logging
- provide backup/restore scripts and runbook
- update dashboard metrics
- expand security docs

## Testing
- `pre-commit run --files services/gateway/app/auth.py .env.example .env.dev.ports`
- `pre-commit run --files services/gateway/app/app.py services/_shared/audit.py`
- `pre-commit run --files scripts/backup_neo4j.sh scripts/restore_neo4j.sh scripts/backup_opensearch.sh scripts/restore_opensearch.sh scripts/backup_postgres.sh scripts/restore_postgres.sh docs/runbooks/backup-recovery.en.md docs/runbooks/backup-recovery.de.md`
- `pre-commit run --files observability/dashboards/gateway_opa.json`
- `pre-commit run --files services/gateway/tests/fixtures/keys.py services/gateway/tests/test_auth.py services/gateway/tests/test_opa.py services/gateway/tests/conftest.py`
- `pytest -o addopts="" services/gateway/tests/test_auth.py services/gateway/tests/test_opa.py` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a64293e88324b171692445a04fb6