### PR TITLE
feat: basic geospatial layer

### DIFF
--- a/apps/frontend/src/__tests__/map-panel.smoke.spec.tsx
+++ b/apps/frontend/src/__tests__/map-panel.smoke.spec.tsx
@@ -1,0 +1,22 @@
+import { render, waitFor } from '@testing-library/react';
+import MapPanel from '@/components/MapPanel';
+import React from 'react';
+import { vi } from 'vitest';
+
+describe('MapPanel', () => {
+  it('renders and fetches layers', async () => {
+    global.fetch = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () =>
+          url.includes('/geo/entities')
+            ? { type: 'FeatureCollection', features: [] }
+            : { items: [] },
+      }) as any
+    );
+
+    render(<MapPanel />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  });
+});

--- a/docs/geo/quickstart.md
+++ b/docs/geo/quickstart.md
@@ -1,0 +1,21 @@
+# Geospatial Quickstart
+
+This guide shows how to work with the geospatial layer.
+
+## API
+
+`GET /geo/entities` returns a GeoJSON `FeatureCollection` of known entity locations. A bounding box can filter the result:
+
+```sh
+curl "http://localhost:8403/geo/entities?bbox=10,47,12,49"
+```
+
+## Frontend
+
+Run the frontend and open the map panel:
+
+```sh
+npm run dev:fe
+```
+
+The map displays entity points and uploaded layers. Use the *Entities* toggle to show or hide built-in data.

--- a/services/graph-views/tests/test_geo_entities.py
+++ b/services/graph-views/tests/test_geo_entities.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+
+def test_geo_entities_smoke(app_client: TestClient):
+    resp = app_client.get("/geo/entities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) >= 1
+
+
+def test_geo_entities_bbox(app_client: TestClient):
+    resp = app_client.get("/geo/entities", params={"bbox": "10,47,12,49"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["features"]) == 1


### PR DESCRIPTION
## Summary
- add `/geo/entities` endpoint returning GeoJSON with optional bbox filter
- show entity layer on map with toggle and deep links
- smoke tests and quickstart docs

## Testing
- `python -m pytest services/graph-views/tests/test_geo_entities.py`
- `npm -w apps/frontend test src/__tests__/map-panel.smoke.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c6b03dba1c8324a52b074c60903e14