### PR TITLE
Ops controller and UI for managing compose stacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,3 +138,12 @@ CH_PASSWORD=
 # Multi-Tenancy
 IT_TENANCY_MODE=single        # single|multi
 IT_TENANT_CLAIM=tenant        # OIDC claim für Tenant/Org
+# --- Ops GUI / Infra Control ---
+IT_OPS_ENABLE=0                    # 0=aus (Default), 1=an
+IT_OPS_MODE=docker                 # docker | k8s (k8s später)
+IT_DOCKER_SOCKET=/var/run/docker.sock
+IT_OPS_ALLOW_SHELL=0               # niemals Shell erlauben
+IT_OPS_LOCK_TIMEOUT_SEC=120
+IT_OPS_LOG_TAIL_LINES=300
+IT_OPS_COMPOSE_BIN=docker compose  # oder 'docker-compose' je nach System
+IT_OPS_STACKS_FILE=infra/ops/stacks.yaml

--- a/apps/frontend/lib/ops.ts
+++ b/apps/frontend/lib/ops.ts
@@ -1,0 +1,15 @@
+export async function listStacks() { return (await fetch(`/api/ops/stacks`)).json(); }
+export async function stackStatus(name:string) { return (await fetch(`/api/ops/stacks/${name}/status`)).json(); }
+export async function stackUp(name:string) { return (await fetch(`/api/ops/stacks/${name}/up`, {method:"POST"})).json(); }
+export async function stackDown(name:string) { return (await fetch(`/api/ops/stacks/${name}/down`, {method:"POST"})).json(); }
+export async function stackRestart(name:string) { return (await fetch(`/api/ops/stacks/${name}/restart`, {method:"POST"})).json(); }
+export async function stackScale(name:string, service:string, replicas:number) {
+  const p = new URLSearchParams({ service, replicas: String(replicas) });
+  return (await fetch(`/api/ops/stacks/${name}/scale?${p}`, {method:"POST"})).json();
+}
+export function streamLogs(name:string, opts?:{service?:string; tail?:number; signal?:AbortSignal}) {
+  const p = new URLSearchParams();
+  if (opts?.service) p.set("service", opts.service);
+  if (opts?.tail) p.set("tail", String(opts.tail));
+  return fetch(`/api/ops/stacks/${name}/logs?${p}`, { signal: opts?.signal });
+}

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -27,6 +27,10 @@ const withExistingRewrites = (rewrites = []) => {
     source: "/api/plugins/:path*",
     destination: `${PLUGINS}/plugins/:path*`,
   });
+  out = add(out, {
+    source: "/api/ops/:path*",
+    destination: `${GATEWAY}/ops/:path*`,
+  });
   return out;
 };
 

--- a/apps/frontend/pages/settings.tsx
+++ b/apps/frontend/pages/settings.tsx
@@ -36,8 +36,10 @@ import {
 } from "@/lib/endpoints";
 import SettingsGateway from "@/components/settings/SettingsGateway";
 import SettingsGraphDeepLink from "@/components/settings/SettingsGraphDeepLink";
+import OpsTab from "@/components/settings/OpsTab";
+import { useAuth } from "@/components/auth/AuthProvider";
 
-type SettingsTab = 'endpoints' | 'gateway' | 'appearance' | 'notifications' | 'security' | 'about';
+type SettingsTab = 'endpoints' | 'ops' | 'gateway' | 'appearance' | 'notifications' | 'security' | 'about';
 
 interface ServiceEndpoint {
   key: keyof EndpointSettings;
@@ -143,6 +145,11 @@ export default function SettingsPage() {
     systemAlerts: true,
     graphUpdates: false
   });
+
+  const { user } = useAuth();
+  const roles = user?.roles || [];
+  const FEATURE_OPS = process.env.NEXT_PUBLIC_FEATURE_OPS === "1";
+  const hasOpsRole = roles.includes("admin") || roles.includes("ops");
 
   const handleEndpointTest = async (endpoint: ServiceEndpoint) => {
     const url = sanitizeUrl(endpointValues[endpoint.key] || '');
@@ -328,6 +335,9 @@ export default function SettingsPage() {
         {/* Tab Navigation */}
         <div className="flex flex-wrap gap-2 bg-gray-50 dark:bg-gray-800 p-2 rounded-lg">
           <TabButton id="endpoints" label="API Endpoints" icon={Server} />
+          {FEATURE_OPS && hasOpsRole && (
+            <TabButton id="ops" label="Ops" icon={Monitor} />
+          )}
           <TabButton id="gateway" label="Gateway" icon={Network} />
           <TabButton id="appearance" label="Appearance" icon={Palette} />
           <TabButton id="notifications" label="Notifications" icon={Bell} />
@@ -455,6 +465,9 @@ export default function SettingsPage() {
           )}
 
           {/* Gateway Tab */}
+          {FEATURE_OPS && hasOpsRole && activeTab === 'ops' && (
+            <OpsTab />
+          )}
           {activeTab === 'gateway' && (
             <Panel>
               <div className="space-y-4">

--- a/apps/frontend/src/components/settings/OpsTab.tsx
+++ b/apps/frontend/src/components/settings/OpsTab.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import Panel from '@/components/layout/Panel';
+import Button from '@/components/ui/Button';
+import {
+  listStacks,
+  stackStatus,
+  stackUp,
+  stackDown,
+  stackRestart,
+  stackScale,
+  streamLogs,
+} from '@/lib/ops';
+
+interface StackInfo {
+  title: string;
+  files: string[];
+}
+
+export default function OpsTab() {
+  const [stacks, setStacks] = useState<Record<string, StackInfo>>({});
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<any | null>(null);
+  const [logText, setLogText] = useState('');
+  const [logStack, setLogStack] = useState<string | null>(null);
+
+  useEffect(() => {
+    listStacks().then((d) => setStacks(d.stacks || {}));
+  }, []);
+
+  const handle = async (action: string, name: string) => {
+    setLoading(true);
+    try {
+      if (action === 'status') setStatus(await stackStatus(name));
+      if (action === 'up') await stackUp(name);
+      if (action === 'down') await stackDown(name);
+      if (action === 'restart') await stackRestart(name);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLogs = async (name: string) => {
+    const controller = new AbortController();
+    setLogText('');
+    setLogStack(name);
+    const res = await streamLogs(name, { signal: controller.signal });
+    const reader = res.body?.getReader();
+    if (!reader) return;
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      setLogText((t) => t + decoder.decode(value));
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 dark:text-slate-400">Aktionen werden protokolliert (Audit)</p>
+      {Object.entries(stacks).map(([name, info]) => (
+        <Panel key={name} className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-medium">{info.title} ({name})</h3>
+            <div className="space-x-2">
+              <Button size="sm" onClick={() => handle('status', name)} disabled={loading}>Status</Button>
+              <Button size="sm" onClick={() => handle('up', name)} disabled={loading}>Start</Button>
+              <Button size="sm" onClick={() => handle('down', name)} disabled={loading}>Stop</Button>
+              <Button size="sm" onClick={() => handle('restart', name)} disabled={loading}>Restart</Button>
+              <Button size="sm" onClick={() => handleLogs(name)} disabled={loading}>Logs</Button>
+            </div>
+          </div>
+          {status?.stack === name && (
+            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40">
+              {JSON.stringify(status.services, null, 2)}
+            </pre>
+          )}
+          {logStack === name && (
+            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40 whitespace-pre-wrap">
+              {logText}
+            </pre>
+          )}
+        </Panel>
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/tests/ops-tab.spec.tsx
+++ b/apps/frontend/tests/ops-tab.spec.tsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import OpsTab from '@/components/settings/OpsTab';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('OpsTab', () => {
+  it('lists stacks and triggers start', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ json: async () => ({ stacks: { core: { title: 'Core', files: [] } } }) })
+      .mockResolvedValue({ json: async () => ({ ok: true }) });
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    render(<OpsTab />);
+    await screen.findByText(/Core/);
+    fireEvent.click(screen.getByText('Start'));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/ops/stacks/core/up', { method: 'POST' }));
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,24 @@ services:
       interval: 10s
       timeout: 3s
       retries: 10
+  ops-controller:
+    build:
+      context: ./services/ops-controller
+    image: infoterminal/ops-controller:0.1
+    environment:
+      - IT_OPS_ENABLE=${IT_OPS_ENABLE:-0}
+      - IT_OPS_MODE=${IT_OPS_MODE:-docker}
+      - IT_DOCKER_SOCKET=${IT_DOCKER_SOCKET:-/var/run/docker.sock}
+      - IT_OPS_COMPOSE_BIN=${IT_OPS_COMPOSE_BIN:-docker compose}
+      - IT_OPS_STACKS_FILE=${IT_OPS_STACKS_FILE:-infra/ops/stacks.yaml}
+      - IT_OPS_LOG_TAIL_LINES=${IT_OPS_LOG_TAIL_LINES:-300}
+      - IT_OPS_LOCK_TIMEOUT_SEC=${IT_OPS_LOCK_TIMEOUT_SEC:-120}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/workspace:ro
+    networks:
+      - default
+    restart: unless-stopped
   # Optional modules --------------------------------------------------
   aleph:
     profiles: ["aleph"]

--- a/docs/dev/en/ops/controller.md
+++ b/docs/dev/en/ops/controller.md
@@ -1,0 +1,19 @@
+# Ops Controller
+
+FastAPI-Service zur Steuerung erlaubter Docker-Compose-Stacks.
+
+## Endpoints
+- `GET /ops/stacks` – Liste erlaubter Stacks aus `infra/ops/stacks.yaml`
+- `GET /ops/stacks/{name}/status`
+- `POST /ops/stacks/{name}/up|down|restart`
+- `POST /ops/stacks/{name}/scale?service=x&replicas=n`
+- `GET /ops/stacks/{name}/logs`
+
+## Sicherheit
+- Aktivierung über `IT_OPS_ENABLE=1`
+- RBAC per `X-Roles` Header (`admin|ops`)
+- Keine Shell-Ausführung, nur whitelisted Compose-Dateien
+- Docker-Socket wird benötigt; nur in vertrauenswürdigen Umgebungen nutzen
+
+## Audit
+Alle Mutationen und Log-Aufrufe werden mit `_shared.audit.audit_log` protokolliert.

--- a/docs/user/de/ops-gui.md
+++ b/docs/user/de/ops-gui.md
@@ -1,0 +1,10 @@
+# Ops GUI
+
+Die Ops-GUI ermöglicht das Starten, Stoppen und Überwachen vordefinierter Docker-Stacks. Aktionen sind nur verfügbar, wenn `IT_OPS_ENABLE=1` gesetzt ist und der angemeldete Nutzer die Rolle `admin` oder `ops` besitzt.
+
+## Funktionen
+- Auflistung erlaubter Stacks (`/api/ops/stacks`)
+- Statusabfrage und Logs je Stack
+- Start, Stop, Restart und Scale einzelner Services
+
+Alle Aktionen werden auditiert. In Produktivumgebungen sollte der Zugriff nur über VPN/SSO erfolgen. Der Docker-Socket erlaubt privilegierte Operationen.

--- a/infra/ops/stacks.yaml
+++ b/infra/ops/stacks.yaml
@@ -1,0 +1,20 @@
+version: 1
+stacks:
+  core:
+    title: Core Stack
+    files: ["docker-compose.yml", "docker-compose.gateway.yml"]
+  graph:
+    title: Graph & Neo4j
+    files: ["docker-compose.neo.yml", "docker-compose.graph-views.yml"]
+  nlp:
+    title: NLP & Doc Entities
+    files: ["docker-compose.nlp.yml"]
+  observability:
+    title: Observability
+    files: ["docker-compose.observability.yml"]
+  opa:
+    title: OPA/Policy
+    files: ["docker-compose.opa.yml"]
+  agents:
+    title: Agents (Flowise, etc.)
+    files: ["docker-compose.agents.yml"]

--- a/services/ops-controller/app.py
+++ b/services/ops-controller/app.py
@@ -1,0 +1,157 @@
+import os, subprocess, shlex, time, json, threading
+from pathlib import Path
+from typing import List, Dict, Optional
+import yaml
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse, JSONResponse
+from _shared.audit import audit_log
+
+APP = FastAPI(title="Ops Controller", version="0.1.0")
+
+ENABLED = os.getenv("IT_OPS_ENABLE","0") == "1"
+MODE = os.getenv("IT_OPS_MODE","docker")
+COMPOSE = os.getenv("IT_OPS_COMPOSE_BIN","docker compose")
+STACKS_FILE = Path(os.getenv("IT_OPS_STACKS_FILE","infra/ops/stacks.yaml"))
+LOCK_TIMEOUT = int(os.getenv("IT_OPS_LOCK_TIMEOUT_SEC","120"))
+TAIL = os.getenv("IT_OPS_LOG_TAIL_LINES","300")
+SOCKET = os.getenv("IT_DOCKER_SOCKET","/var/run/docker.sock")
+
+_lock = threading.Lock()
+_lock_at = 0.0
+
+def _require_enabled():
+    if not ENABLED:
+        raise HTTPException(403, "Ops is disabled. Set IT_OPS_ENABLE=1")
+    if MODE != "docker":
+        raise HTTPException(400, f"Mode {MODE} not supported yet")
+
+def _require_rbac(req: Request):
+    roles = (req.headers.get("X-Roles") or req.headers.get("x-roles") or "").split(",")
+    scope = req.headers.get("X-Scope","")
+    if not any(r.strip() in ("admin","ops") for r in roles):
+        raise HTTPException(403, "RBAC: admin|ops required")
+
+def _stacks() -> Dict[str, Dict]:
+    if not STACKS_FILE.exists():
+        return {"stacks": {}}
+    data = yaml.safe_load(STACKS_FILE.read_text(encoding="utf-8")) or {}
+    return { "stacks": {k:v for k,v in (data.get("stacks") or {}).items()} }
+
+def _compose_cmd(files: List[str], args: List[str]) -> List[str]:
+    cmd = []
+    for f in files:
+        cmd += shlex.split(f"-f {f}")
+    return shlex.split(COMPOSE) + cmd + args
+
+def _run(files: List[str], args: List[str], timeout: int=LOCK_TIMEOUT) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    return subprocess.run(_compose_cmd(files,args), stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout, env=env)
+
+def _lock_guard():
+    global _lock_at
+    ok = _lock.acquire(timeout=LOCK_TIMEOUT)
+    if not ok:
+        raise HTTPException(423, "Ops busy, try again later")
+    _lock_at = time.time()
+
+def _unlock():
+    if _lock.locked(): _lock.release()
+
+
+def _audit(action: str, req: Request, **extra):
+    audit_log(action, req.headers.get("X-User-Id", ""), req.headers.get("X-Tenant-Id", ""), **extra)
+
+@APP.get("/ops/stacks")
+def list_stacks(request: Request):
+    _require_enabled(); _require_rbac(request)
+    return _stacks()
+
+@APP.get("/ops/stacks/{name}/status")
+def stack_status(name: str, request: Request):
+    _require_enabled(); _require_rbac(request)
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    p = _run(files, ["ps", "--format", "json"])
+    if p.returncode != 0:
+        raise HTTPException(500, p.stderr.decode())
+    lines = [json.loads(l) for l in p.stdout.decode().splitlines() if l.strip()]
+    return {"stack": name, "services": lines}
+
+@APP.post("/ops/stacks/{name}/up")
+def stack_up(name: str, request: Request):
+    _require_enabled(); _require_rbac(request)
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    _lock_guard()
+    try:
+        p = _run(files, ["up","-d"])
+        if p.returncode != 0: raise HTTPException(500, p.stderr.decode())
+        _audit("stack_up", request, stack=name)
+        return {"ok": True, "stack": name}
+    finally: _unlock()
+
+@APP.post("/ops/stacks/{name}/down")
+def stack_down(name: str, request: Request):
+    _require_enabled(); _require_rbac(request)
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    _lock_guard()
+    try:
+        p = _run(files, ["down"])
+        if p.returncode != 0: raise HTTPException(500, p.stderr.decode())
+        _audit("stack_down", request, stack=name)
+        return {"ok": True, "stack": name}
+    finally: _unlock()
+
+@APP.post("/ops/stacks/{name}/restart")
+def stack_restart(name: str, request: Request):
+    _require_enabled(); _require_rbac(request)
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    _lock_guard()
+    try:
+        p = _run(files, ["up","-d","--remove-orphans"])
+        if p.returncode != 0: raise HTTPException(500, p.stderr.decode())
+        _audit("stack_restart", request, stack=name)
+        return {"ok": True, "stack": name}
+    finally: _unlock()
+
+@APP.post("/ops/stacks/{name}/scale")
+def stack_scale(name: str, service: str, replicas: int, request: Request):
+    _require_enabled(); _require_rbac(request)
+    if replicas < 0 or replicas > 10:
+        raise HTTPException(400, "replicas out of range (0..10)")
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    _lock_guard()
+    try:
+        p = _run(files, ["up","-d","--scale", f"{service}={replicas}"])
+        if p.returncode != 0: raise HTTPException(500, p.stderr.decode())
+        _audit("stack_scale", request, stack=name, service=service, replicas=replicas)
+        return {"ok": True, "stack": name, "service": service, "replicas": replicas}
+    finally: _unlock()
+
+@APP.get("/ops/stacks/{name}/logs")
+def stack_logs(name: str, service: Optional[str]=None, tail: Optional[int]=None, request: Request=None):
+    _require_enabled(); _require_rbac(request)
+    stacks = _stacks()["stacks"]
+    if name not in stacks: raise HTTPException(404,"unknown stack")
+    files = stacks[name]["files"]
+    N = str(tail or TAIL)
+    _audit("stack_logs", request, stack=name, service=service)
+
+    def stream():
+        args = ["logs","-f","--tail", N]
+        if service: args.append(service)
+        with subprocess.Popen(_compose_cmd(files, args), stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as proc:
+            try:
+                for line in iter(proc.stdout.readline, b''):
+                    yield line
+            except GeneratorExit:
+                proc.terminate()
+    return StreamingResponse(stream(), media_type="text/plain")

--- a/services/ops-controller/requirements.txt
+++ b/services/ops-controller/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+pyyaml
+anyio

--- a/services/ops-controller/tests/test_ops.py
+++ b/services/ops-controller/tests/test_ops.py
@@ -1,0 +1,77 @@
+import importlib.util
+from pathlib import Path
+import sys
+import subprocess
+import types
+from fastapi.testclient import TestClient
+
+def load_app(monkeypatch):
+    monkeypatch.setenv("IT_OPS_ENABLE", "1")
+    services_dir = Path(__file__).resolve().parents[2]
+    sys.path.append(str(services_dir))
+    path = services_dir / "ops-controller" / "app.py"
+    spec = importlib.util.spec_from_file_location("ops_controller", path)
+    module = importlib.util.module_from_spec(spec)  # type: ignore
+    spec.loader.exec_module(module)  # type: ignore
+    return module.APP
+
+def test_list_and_status(monkeypatch, tmp_path):
+    yaml_path = tmp_path / "stacks.yaml"
+    yaml_path.write_text('version:1\nstacks:\n  core:\n    title: Core\n    files: ["docker-compose.yml"]')
+    monkeypatch.setenv("IT_OPS_STACKS_FILE", str(yaml_path))
+
+    def mock_run(cmd, stdout, stderr, timeout, env):
+        return subprocess.CompletedProcess(cmd, 0, b'{}\n', b'')
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    r = client.get("/ops/stacks", headers={"X-Roles": "ops"})
+    assert r.status_code == 200
+    r = client.get("/ops/stacks/core/status", headers={"X-Roles": "ops"})
+    assert r.status_code == 200
+
+def test_up_down(monkeypatch, tmp_path):
+    yaml_path = tmp_path / "stacks.yaml"
+    yaml_path.write_text('version:1\nstacks:\n  core:\n    title: Core\n    files: ["docker-compose.yml"]')
+    monkeypatch.setenv("IT_OPS_STACKS_FILE", str(yaml_path))
+    monkeypatch.setenv("IT_OPS_ENABLE", "1")
+
+    def mock_run(cmd, stdout, stderr, timeout, env):
+        return subprocess.CompletedProcess(cmd, 0, b'', b'')
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    for action in ["up", "down", "restart"]:
+        r = client.post(f"/ops/stacks/core/{action}", headers={"X-Roles": "ops"})
+        assert r.status_code == 200
+
+def test_scale_range(monkeypatch, tmp_path):
+    yaml_path = tmp_path / "stacks.yaml"
+    yaml_path.write_text('version:1\nstacks:\n  core:\n    title: Core\n    files: ["docker-compose.yml"]')
+    monkeypatch.setenv("IT_OPS_STACKS_FILE", str(yaml_path))
+    monkeypatch.setenv("IT_OPS_ENABLE", "1")
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    r = client.post("/ops/stacks/core/scale?service=web&replicas=11", headers={"X-Roles": "ops"})
+    assert r.status_code == 400
+
+def test_logs(monkeypatch, tmp_path):
+    yaml_path = tmp_path / "stacks.yaml"
+    yaml_path.write_text('version:1\nstacks:\n  core:\n    title: Core\n    files: ["docker-compose.yml"]')
+    monkeypatch.setenv("IT_OPS_STACKS_FILE", str(yaml_path))
+    monkeypatch.setenv("IT_OPS_ENABLE", "1")
+
+    class DummyProc:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def terminate(self):
+            pass
+        stdout = types.SimpleNamespace(readline=lambda: b'line\n')
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: DummyProc())
+    app = load_app(monkeypatch)
+    client = TestClient(app)
+    r = client.get("/ops/stacks/core/logs", headers={"X-Roles": "ops"})
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- add env toggles and allowlisted stack mapping
- fastapi ops-controller with docker compose control and audit
- gateway proxy and frontend ops tab with utilities

## Testing
- `pytest services/ops-controller/tests/test_ops.py` *(fails: No module named '_shared.audit')*
- `pnpm test tests/ops-tab.spec.tsx` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf59fb2083249c427564fb6e985b