### PR TITLE
feat(frontend): enhance Ops tab with scaling controls

### DIFF
--- a/apps/frontend/e2e/specs/ops-tab.spec.ts
+++ b/apps/frontend/e2e/specs/ops-tab.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { dummyLogin } from '../helpers/auth';
+
+test('ops tab shows stacks and logs', async ({ page }) => {
+  test.skip(process.env.NEXT_PUBLIC_FEATURE_OPS !== '1', 'ops feature disabled');
+
+  await page.route('**/api/ops/stacks', route =>
+    route.fulfill({ body: JSON.stringify({ stacks: { core: { title: 'Core', files: [] } } }) })
+  );
+  await page.route('**/api/ops/stacks/core/status', route =>
+    route.fulfill({ body: JSON.stringify({ stack: 'core', services: [] }) })
+  );
+  await page.route('**/api/ops/stacks/core/up', route =>
+    route.fulfill({ body: JSON.stringify({ ok: true }) })
+  );
+  await page.route('**/api/ops/stacks/core/logs', route =>
+    route.fulfill({ body: 'line1\n' })
+  );
+
+  await page.goto('/settings');
+  await dummyLogin(page);
+  await page.goto('/settings');
+  await page.getByRole('tab', { name: 'Ops' }).click();
+  await expect(page.getByText('Core')).toBeVisible();
+  await page.getByText('Logs').click();
+  await expect(page.getByText('line1')).toBeVisible();
+});

--- a/apps/frontend/src/components/settings/OpsTab.tsx
+++ b/apps/frontend/src/components/settings/OpsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import Panel from '@/components/layout/Panel';
 import Button from '@/components/ui/Button';
+import { toast } from '@/components/ui/toast';
 import {
   listStacks,
   stackStatus,
@@ -22,6 +23,9 @@ export default function OpsTab() {
   const [status, setStatus] = useState<any | null>(null);
   const [logText, setLogText] = useState('');
   const [logStack, setLogStack] = useState<string | null>(null);
+  const [scaleService, setScaleService] = useState('');
+  const [scaleReplicas, setScaleReplicas] = useState(1);
+  const [logController, setLogController] = useState<AbortController | null>(null);
 
   useEffect(() => {
     listStacks().then((d) => setStacks(d.stacks || {}));
@@ -34,24 +38,57 @@ export default function OpsTab() {
       if (action === 'up') await stackUp(name);
       if (action === 'down') await stackDown(name);
       if (action === 'restart') await stackRestart(name);
+    } catch (e) {
+      toast('Action failed', { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleScale = async (name: string) => {
+    if (!scaleService) {
+      toast('Select service', { variant: 'error' });
+      return;
+    }
+    if (scaleReplicas < 0 || scaleReplicas > 10) {
+      toast('Replicas 0..10', { variant: 'error' });
+      return;
+    }
+    setLoading(true);
+    try {
+      await stackScale(name, scaleService, scaleReplicas);
+    } catch (e) {
+      toast('Scale failed', { variant: 'error' });
     } finally {
       setLoading(false);
     }
   };
 
   const handleLogs = async (name: string) => {
+    logController?.abort();
     const controller = new AbortController();
+    setLogController(controller);
     setLogText('');
     setLogStack(name);
-    const res = await streamLogs(name, { signal: controller.signal });
-    const reader = res.body?.getReader();
-    if (!reader) return;
-    const decoder = new TextDecoder();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      setLogText((t) => t + decoder.decode(value));
+    try {
+      const res = await streamLogs(name, { signal: controller.signal });
+      const reader = res.body?.getReader();
+      if (!reader) return;
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        setLogText((t) => t + decoder.decode(value));
+      }
+    } catch (e) {
+      toast('Log stream failed', { variant: 'error' });
     }
+  };
+
+  const stopLogs = () => {
+    logController?.abort();
+    setLogController(null);
+    setLogStack(null);
   };
 
   return (
@@ -70,14 +107,48 @@ export default function OpsTab() {
             </div>
           </div>
           {status?.stack === name && (
-            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40">
-              {JSON.stringify(status.services, null, 2)}
-            </pre>
+            <>
+              <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40">
+                {JSON.stringify(status.services, null, 2)}
+              </pre>
+              <div className="flex items-center space-x-2">
+                <select
+                  className="border rounded p-1 text-sm"
+                  value={scaleService}
+                  onChange={(e) => setScaleService(e.target.value)}
+                >
+                  <option value="">service</option>
+                  {status.services?.map((s: any) => (
+                    <option key={s.Service} value={s.Service}>
+                      {s.Service}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="number"
+                  min={0}
+                  max={10}
+                  className="border rounded p-1 w-16 text-sm"
+                  value={scaleReplicas}
+                  onChange={(e) => setScaleReplicas(Number(e.target.value))}
+                />
+                <Button size="sm" onClick={() => handleScale(name)} disabled={loading}>
+                  Scale
+                </Button>
+              </div>
+            </>
           )}
           {logStack === name && (
-            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40 whitespace-pre-wrap">
-              {logText}
-            </pre>
+            <>
+              <div className="flex justify-end">
+                <Button size="sm" onClick={stopLogs}>
+                  Stop
+                </Button>
+              </div>
+              <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-auto max-h-40 whitespace-pre-wrap">
+                {logText}
+              </pre>
+            </>
           )}
         </Panel>
       ))}

--- a/apps/frontend/tests/ops-tab.spec.tsx
+++ b/apps/frontend/tests/ops-tab.spec.tsx
@@ -3,16 +3,48 @@ import OpsTab from '@/components/settings/OpsTab';
 import { describe, it, expect, vi } from 'vitest';
 
 describe('OpsTab', () => {
-  it('lists stacks and triggers start', async () => {
-    const mockFetch = vi.fn()
-      .mockResolvedValueOnce({ json: async () => ({ stacks: { core: { title: 'Core', files: [] } } }) })
-      .mockResolvedValue({ json: async () => ({ ok: true }) });
+  it('handles start, scale and logs', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('line1\n'));
+        controller.close();
+      }
+    });
+    const mockFetch = vi.fn((url: string, opts?: any) => {
+      if (url === '/api/ops/stacks')
+        return Promise.resolve({ json: async () => ({ stacks: { core: { title: 'Core', files: [] } } }) });
+      if (url === '/api/ops/stacks/core/status')
+        return Promise.resolve({ json: async () => ({ stack: 'core', services: [{ Service: 'web' }] }) });
+      if (url.startsWith('/api/ops/stacks/core/scale'))
+        return Promise.resolve({ json: async () => ({ ok: true }) });
+      if (url.startsWith('/api/ops/stacks/core/logs')) return Promise.resolve({ body: stream });
+      return Promise.resolve({ json: async () => ({ ok: true }) });
+    });
     // @ts-ignore
     global.fetch = mockFetch;
 
     render(<OpsTab />);
     await screen.findByText(/Core/);
     fireEvent.click(screen.getByText('Start'));
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/ops/stacks/core/up', { method: 'POST' }));
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith('/api/ops/stacks/core/up', { method: 'POST' })
+    );
+
+    fireEvent.click(screen.getByText('Status'));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/ops/stacks/core/status', undefined));
+    const select = await screen.findByRole('combobox');
+    fireEvent.change(select, { target: { value: 'web' } });
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '2' } });
+    fireEvent.click(screen.getByText('Scale'));
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ops/stacks/core/scale?service=web&replicas=2',
+        { method: 'POST' }
+      )
+    );
+
+    fireEvent.click(screen.getByText('Logs'));
+    await screen.findByText('line1');
   });
 });


### PR DESCRIPTION
## Summary
- add scaling controls and log streaming stop to Ops settings tab
- cover Ops tab with unit and e2e smoke tests

## Testing
- `npm -w apps/frontend test` *(fails: useAuth must be used within an AuthProvider, missing switch role)*
- `npm --workspace apps/frontend run test:e2e` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c4dc18088324aa9ced897b782122