### PR TITLE
fix: allow fork syscalls in seccomp profile

### DIFF
--- a/security/runtime/seccomp/infoterminal-default.json
+++ b/security/runtime/seccomp/infoterminal-default.json
@@ -350,15 +350,7 @@
         "clone",
         "clone3"
       ],
-      "action": "SCMP_ACT_ALLOW",
-      "args": [
-        {
-          "index": 0,
-          "op": "SCMP_CMP_MASKED_EQ",
-          "datum": 2080505856,
-          "datumTwo": 2080505856
-        }
-      ]
+      "action": "SCMP_ACT_ALLOW"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- allow clone and clone3 syscalls without extra seccomp constraints so entrypoints can fork

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fbd765008324a3277798a961b250