### PR TITLE
Add Helm chart skeleton and lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,3 +328,15 @@ jobs:
         run: |
           echo "vuln_policy_images failed with status ${{ steps.images.outputs.images_status }}"
           exit 1
+
+  helm_lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Lint InfoTerminal chart
+        run: helm lint deploy/helm/infoterminal

--- a/deploy/helm/infoterminal/Chart.yaml
+++ b/deploy/helm/infoterminal/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: infoterminal
+description: Helm chart skeleton for deploying the InfoTerminal platform components.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - infoterminal
+  - knowledge-graph
+home: https://github.com/InfoTerminal/InfoTerminal
+maintainers:
+  - name: InfoTerminal Team
+    email: ops@infoterminal.local

--- a/deploy/helm/infoterminal/templates/_helpers.tpl
+++ b/deploy/helm/infoterminal/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "infoterminal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "infoterminal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "infoterminal.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "infoterminal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "infoterminal.labels" -}}
+helm.sh/chart: {{ include "infoterminal.chart" . }}
+{{ include "infoterminal.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "infoterminal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "infoterminal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "infoterminal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "infoterminal.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/infoterminal/templates/configmap.yaml
+++ b/deploy/helm/infoterminal/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- range .Values.configMaps }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" (include "infoterminal.fullname" $) .name | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "infoterminal.labels" $ | nindent 4 }}
+data:
+  {{- toYaml .data | nindent 2 }}
+---
+{{- end }}

--- a/deploy/helm/infoterminal/templates/deployment.yaml
+++ b/deploy/helm/infoterminal/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "infoterminal.fullname" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "infoterminal.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+  template:
+    metadata:
+      labels:
+        {{- include "infoterminal.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "infoterminal.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "infoterminal.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- toYaml .Values.containerPorts | nindent 12 }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.resourcesPreset .Values.resourcesPreset.enabled }}
+          resources:
+            {{- toYaml (omit .Values.resourcesPreset "enabled") | nindent 12 }}
+          {{- else if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.probes.liveness.enabled .Values.probes.liveness.path }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: {{ .Values.probes.liveness.port }}
+            {{- omit .Values.probes.liveness "enabled" "path" "port" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if and .Values.probes.readiness.enabled .Values.probes.readiness.path }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: {{ .Values.probes.readiness.port }}
+            {{- omit .Values.probes.readiness "enabled" "path" "port" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/infoterminal/templates/hpa.yaml
+++ b/deploy/helm/infoterminal/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "infoterminal.fullname" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "infoterminal.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/infoterminal/templates/ingress.yaml
+++ b/deploy/helm/infoterminal/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "infoterminal.fullname" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+  {{- $rawAnnotations := default (dict) .Values.ingress.annotations }}
+  {{- $annotations := merge (dict) $rawAnnotations }}
+  {{- $hasClassAnnotation := hasKey $rawAnnotations "kubernetes.io/ingress.class" }}
+  {{- if and .Values.ingress.className (not $hasClassAnnotation) }}
+  {{- $_ := set $annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
+  {{- end }}
+  {{- if $annotations }}
+  annotations:
+    {{- toYaml $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (not $hasClassAnnotation) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "infoterminal.fullname" $ }}
+                port:
+                  {{- if .servicePort }}
+                  name: {{ .servicePort }}
+                  {{- else }}
+                  number: {{ $.Values.service.port }}
+                  {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/infoterminal/templates/secret.yaml
+++ b/deploy/helm/infoterminal/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.secrets.enabled (or .Values.secrets.data .Values.secrets.stringData) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-secret" (include "infoterminal.fullname" .)) .Values.secrets.name }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+{{- if .Values.secrets.data }}
+data:
+  {{- toYaml .Values.secrets.data | nindent 2 }}
+{{- end }}
+{{- if .Values.secrets.stringData }}
+stringData:
+  {{- toYaml .Values.secrets.stringData | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/infoterminal/templates/service.yaml
+++ b/deploy/helm/infoterminal/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infoterminal.fullname" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "infoterminal.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/infoterminal/templates/serviceaccount.yaml
+++ b/deploy/helm/infoterminal/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "infoterminal.serviceAccountName" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/infoterminal/templates/servicemonitor.yaml
+++ b/deploy/helm/infoterminal/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "infoterminal.fullname" . }}
+  labels:
+    {{- include "infoterminal.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "infoterminal.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/helm/infoterminal/values.yaml
+++ b/deploy/helm/infoterminal/values.yaml
@@ -1,0 +1,113 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/infoterminal/infoterminal
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: http
+  annotations: {}
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+strategy:
+  type: RollingUpdate
+
+containerPorts:
+  - name: http
+    containerPort: 8080
+    protocol: TCP
+
+env: []
+
+envFrom: []
+
+probes:
+  liveness:
+    enabled: true
+    path: /healthz
+    port: http
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readiness:
+    enabled: true
+    path: /readyz
+    port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+    successThreshold: 1
+
+resourcesPreset:
+  enabled: false
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+
+secrets:
+  enabled: false
+  name: ""
+  data: {}
+  stringData: {}
+
+configMaps: []
+  # - name: extra-config
+  #   data:
+  #     APP_ENV: production
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: infoterminal.local
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: http
+  tls: []

--- a/docs/deploy/k8s_helm.md
+++ b/docs/deploy/k8s_helm.md
@@ -1,0 +1,93 @@
+# Kubernetes Deployment mit Helm
+
+Dieser Quickstart beschreibt die neuen Helm-Artefakte unter `deploy/helm/` und zeigt, wie Sie einen InfoTerminal-Dienst als Ausgangspunkt auf einem Kubernetes-Cluster ausrollen.
+
+## Voraussetzungen
+
+- Kubernetes-Cluster (lokal via kind/minikube oder Remote-Cluster)
+- [Helm 3](https://helm.sh/)
+- Optional: Prometheus-Stack, falls der `ServiceMonitor` genutzt werden soll
+
+## Struktur des Charts
+
+```
+deploy/helm/infoterminal/
+├─ Chart.yaml                # Metadaten des Charts
+├─ values.yaml               # Standardwerte (Image, Service, Probes, Ingress)
+└─ templates/
+   ├─ _helpers.tpl           # Namens- und Label-Hilfsfunktionen
+   ├─ configmap.yaml         # Optionale ConfigMaps über `values.configMaps`
+   ├─ deployment.yaml        # Deployment mit Liveness/Readiness Probes
+   ├─ ingress.yaml           # Optionaler Ingress (`values.ingress.enabled`)
+   ├─ secret.yaml            # Optionales Secret (`values.secrets.*`)
+   ├─ service.yaml           # Service (ClusterIP standardmäßig)
+   ├─ serviceaccount.yaml    # ServiceAccount (abschaltbar)
+   └─ servicemonitor.yaml    # Optionales Prometheus CRD
+```
+
+## Werte anpassen
+
+1. Erstellen Sie eine eigene Werte-Datei, z. B. `values.prod.yaml`:
+
+   ```yaml
+   image:
+     repository: ghcr.io/infoterminal/gateway
+     tag: "v0.2.0"
+
+   env:
+     - name: GATEWAY_PORT
+       value: "8080"
+
+   probes:
+     readiness:
+       path: /readyz
+     liveness:
+       path: /healthz
+
+   ingress:
+     enabled: true
+     className: traefik
+     hosts:
+       - host: gateway.example.local
+         paths:
+           - path: /
+             pathType: Prefix
+             servicePort: http
+   ```
+
+2. Hinterlegen Sie vertrauliche Werte getrennt in einer zweiten Datei, z. B. `values.secrets.yaml`:
+
+   ```yaml
+   secrets:
+     enabled: true
+     stringData:
+       OAUTH_CLIENT_SECRET: "<geheim>"
+   ```
+
+   > ⚠️ Speichern Sie diese Datei nicht im Repository und nutzen Sie z. B. `sops` oder einen Secret-Manager.
+
+## Installation
+
+```bash
+helm dependency update deploy/helm/infoterminal  # optional, sobald Dependencies bestehen
+helm lint deploy/helm/infoterminal
+helm upgrade --install infoterminal deploy/helm/infoterminal \
+  --namespace infoterminal --create-namespace \
+  --values values.prod.yaml \
+  --values values.secrets.yaml
+```
+
+## Smoke-Test
+
+```bash
+kubectl -n infoterminal get pods
+kubectl -n infoterminal get svc
+```
+
+Sobald der Pod im Status `Running` ist und die Readiness-Probe grün meldet, sollten Requests über den Service (oder Ingress) erreichbar sein.
+
+## Weiteres Vorgehen
+
+- Ergänzen Sie komponentenspezifische Umgebungsvariablen in `values.yaml`.
+- Aktivieren Sie `serviceMonitor`, wenn Prometheus Metriken einsammeln soll.
+- Fügen Sie zusätzliche Templates (z. B. `HorizontalPodAutoscaler`) hinzu, sobald Lasttests erforderlich sind.


### PR DESCRIPTION
## Summary
- add a vendor-neutral Helm chart skeleton under deploy/helm/infoterminal
- document Helm quickstart steps for Kubernetes deployments
- integrate a helm_lint job in the CI pipeline to validate the chart

## Testing
- helm lint deploy/helm/infoterminal

------
https://chatgpt.com/codex/tasks/task_e_68d80024f7888324b241a74108ed7b2f