### PR TITLE
Add v1.0 upgrade guide and demo script

### DIFF
--- a/artifacts/upgrade/report.md
+++ b/artifacts/upgrade/report.md
@@ -1,0 +1,9 @@
+# v0.2 → v1.0 Synthetic Upgrade Report
+
+| Step | Result | Notes |
+| --- | --- | --- |
+| Seed v0.2 dataset | ✅ | Sample entities and feature flags generated. |
+| Backups | ✅ | Postgres/Neo4j/OpenSearch snapshots written. |
+| Run migrations | ✅ | Added graph scores and staged new flag defaults. |
+| Validate results | ✅ | v1.0 dataset contains new column and updated flags. |
+| Cleanup | ✅ | Workspace preserved after run. |

--- a/artifacts/upgrade/v02_to_v10_demo.sh
+++ b/artifacts/upgrade/v02_to_v10_demo.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPORT_FILE="${SCRIPT_DIR}/report.md"
+
+show_help() {
+  cat <<'USAGE'
+Usage: v02_to_v10_demo.sh [options]
+
+Synthetic upgrade rehearsal for InfoTerminal v0.2 → v1.0.
+
+Options:
+  --workspace <path>   Working directory for the simulated environment (default: ./artifacts/upgrade/workspace)
+  --dry-run            Print the commands without executing them.
+  --keep-workspace     Preserve the workspace after completion (default: workspace removed on success).
+  --help               Display this help message.
+
+Environment variables:
+  DRY_RUN=1            Equivalent to passing --dry-run.
+
+Examples:
+  bash artifacts/upgrade/v02_to_v10_demo.sh --workspace /tmp/infoterminal-demo
+  DRY_RUN=1 bash artifacts/upgrade/v02_to_v10_demo.sh
+USAGE
+}
+
+DRY_RUN=${DRY_RUN:-0}
+KEEP_WORKSPACE=0
+WORKSPACE="${SCRIPT_DIR}/workspace"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workspace)
+      WORKSPACE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --keep-workspace)
+      KEEP_WORKSPACE=1
+      shift
+      ;;
+    --help|-h)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] Unknown option: $1" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '[DRY_RUN] %s\n' "$*"
+  else
+    "$@"
+  fi
+}
+
+log_step() {
+  printf '\n==> %s\n' "$1"
+}
+
+append_report() {
+  local text="$1"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '[DRY_RUN] report += %s\n' "$text"
+  else
+    printf '%s\n' "$text" >> "$REPORT_FILE"
+  fi
+}
+
+prepare_report() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '[DRY_RUN] truncate %s\n' "$REPORT_FILE"
+  else
+    cat <<'HEADER' > "$REPORT_FILE"
+# v0.2 → v1.0 Synthetic Upgrade Report
+
+| Step | Result | Notes |
+| --- | --- | --- |
+HEADER
+  fi
+}
+
+clean_workspace() {
+  if [[ -d "$WORKSPACE" ]]; then
+    log_step "Cleaning existing workspace at $WORKSPACE"
+    run_cmd rm -rf "$WORKSPACE"
+  fi
+  if [[ "$DRY_RUN" != "1" ]]; then
+    rm -f "$REPORT_FILE"
+  fi
+}
+
+create_workspace() {
+  log_step "Creating workspace at $WORKSPACE"
+  run_cmd mkdir -p "$WORKSPACE"/v0_2/{config,data} "$WORKSPACE"/backups "$WORKSPACE"/logs
+}
+
+seed_v02_dataset() {
+  log_step "Seeding synthetic v0.2 dataset"
+  run_cmd bash -c "cat <<'DATA' > '$WORKSPACE/v0_2/data/entities.csv'
+entity_id,name,type
+1,Acme Corp,organization
+2,Jane Doe,person
+DATA"
+  run_cmd bash -c "cat <<'DATA' > '$WORKSPACE/v0_2/config/flags.env'
+DOC_ENTITY_V1=false
+GRAPH_ALGO_V1=false
+GATEWAY_OIDC_ENFORCE=false
+OBS_ENRICH_TRACES=false
+DATA"
+  append_report "| Seed v0.2 dataset | ✅ | Sample entities and feature flags generated. |"
+}
+
+create_backups() {
+  log_step "Creating backup artifacts"
+  run_cmd bash -c "tar -czf '$WORKSPACE/backups/postgres-v0_2.tgz' -C '$WORKSPACE/v0_2/data' entities.csv"
+  run_cmd bash -c "cp '$WORKSPACE/v0_2/data/entities.csv' '$WORKSPACE/backups/neo4j-v0_2.export'"
+  run_cmd bash -c "cp '$WORKSPACE/v0_2/data/entities.csv' '$WORKSPACE/backups/opensearch-v0_2.snapshot'"
+  append_report "| Backups | ✅ | Postgres/Neo4j/OpenSearch snapshots written. |"
+}
+
+apply_migrations() {
+  log_step "Applying simulated migrations"
+  run_cmd mkdir -p "$WORKSPACE/v1_0/data" "$WORKSPACE/v1_0/config"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '[DRY_RUN] python transform %s to %s\n' "$WORKSPACE/v0_2/data/entities.csv" "$WORKSPACE/v1_0/data/entities.csv"
+  else
+    python - "$WORKSPACE/v0_2/data/entities.csv" "$WORKSPACE/v1_0/data/entities.csv" <<'PY'
+import csv
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+with source.open(newline="") as handle, destination.open("w", newline="") as output:
+    reader = csv.reader(handle)
+    writer = csv.writer(output)
+    header = next(reader)
+    header.append("graph_score")
+    writer.writerow(header)
+    for idx, row in enumerate(reader, start=1):
+        row.append(f"{idx * 0.42:.2f}")
+        writer.writerow(row)
+PY
+  fi
+  run_cmd bash -c "cat <<'DATA' > '$WORKSPACE/v1_0/config/flags.env'
+DOC_ENTITY_V1=true
+GRAPH_ALGO_V1=true
+GATEWAY_OIDC_ENFORCE=false
+OBS_ENRICH_TRACES=true
+DATA"
+  append_report "| Run migrations | ✅ | Added graph scores and staged new flag defaults. |"
+}
+
+verify_upgrade() {
+  log_step "Running synthetic verifications"
+  run_cmd bash -c "grep -q 'graph_score' '$WORKSPACE/v1_0/data/entities.csv'"
+  run_cmd bash -c "grep -q 'DOC_ENTITY_V1=true' '$WORKSPACE/v1_0/config/flags.env'"
+  append_report "| Validate results | ✅ | v1.0 dataset contains new column and updated flags. |"
+}
+
+finalize_report() {
+  if [[ "$DRY_RUN" != "1" ]]; then
+    append_report "| Cleanup | ✅ | Workspace $( [[ "$KEEP_WORKSPACE" == "1" ]] && echo 'preserved' || echo 'archived') after run. |"
+  else
+    printf '[DRY_RUN] report += | Cleanup | ...\n'
+  fi
+}
+
+cleanup() {
+  if [[ "$KEEP_WORKSPACE" == "1" ]]; then
+    log_step "Preserving workspace at $WORKSPACE"
+  else
+    log_step "Removing workspace"
+    run_cmd rm -rf "$WORKSPACE"
+  fi
+}
+
+main() {
+  clean_workspace
+  prepare_report
+  create_workspace
+  seed_v02_dataset
+  create_backups
+  apply_migrations
+  verify_upgrade
+  finalize_report
+  cleanup
+  log_step "Synthetic upgrade complete"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '\nReport would be stored at %s\n' "$REPORT_FILE"
+  else
+    printf '\nReport stored at %s\n' "$REPORT_FILE"
+  fi
+}
+
+main "$@"

--- a/docs/release/upgrade_guide.md
+++ b/docs/release/upgrade_guide.md
@@ -1,0 +1,195 @@
+# InfoTerminal Upgrade Guide (v0.2 → v1.0)
+
+This guide documents the supported path to upgrade an InfoTerminal deployment from **version 0.2** to **version 1.0**. Follow every step in order. Each section lists the expected inputs, required flags, and verification commands. The accompanying demo script located at `artifacts/upgrade/v02_to_v10_demo.sh` provides a synthetic end-to-end walk-through that can be adapted for real environments.
+
+---
+
+## Audience & Scope
+- **Audience:** Platform engineers and operators responsible for on-prem or cloud deployments.
+- **Scope:** Application services (`gateway`, `search-api`, `graph-api`, `doc-entities`, `graph-views`), supporting data stores (PostgreSQL, Neo4j, OpenSearch, MinIO object storage), and the observability stack (Prometheus, Grafana, Loki, Tempo).
+- **Out of scope:** Helm chart packaging and Flowise tooling (covered in their own upgrade notes).
+
+> ℹ️ **Downtime expectations:** Plan for a rolling maintenance window of 30–45 minutes. The gateway can remain available if blue/green deployment is supported; otherwise expect a 15 minute outage while migrations complete.
+
+---
+
+## Quick Reference Checklist
+
+| Phase | Description | Key Commands |
+| --- | --- | --- |
+| 0 | Pre-flight validation | `make upgrade-precheck` |
+| 1 | Back up data & configs | `make upgrade-backup` |
+| 2 | Enable v1.0 feature flags | `./deploy/set_flag.sh --release v1.0 --enable` |
+| 3 | Run schema migrations | `make db-migrate` |
+| 4 | Upgrade services | `docker compose -f docker-compose.prod.yml up -d --build` |
+| 5 | Validate post-upgrade health | `./scripts/healthcheck.sh --targets all` |
+| 6 | Execute smoke tests | `make smoke` |
+
+The `make` targets reference shared automation added for v1.0. Adjust paths if your deployment uses custom tooling.
+
+---
+
+## 0. Pre-flight Validation
+1. **Freeze automation**: Pause CI/CD jobs that auto-deploy `main`.
+2. **Confirm versions**:
+   - `git fetch && git checkout tags/v1.0.0`
+   - `cat VERSION` (should read `1.0.0`).
+3. **Check dependencies**:
+   - Docker Engine ≥ 24.0, Compose V2.
+   - Python 3.10+ for admin scripts.
+   - Helm 3.12+ (if using Kubernetes).
+4. **Run validation target**:
+   ```bash
+   make upgrade-precheck
+   ```
+   The target runs static config validation, checks for deprecated environment keys, and ensures that all required secrets are present. Resolve any failures before proceeding.
+
+---
+
+## 1. Back Up Critical Data
+Perform backups immediately before applying migrations.
+
+### 1.1 PostgreSQL (application metadata)
+```bash
+./scripts/backup/postgres.sh \
+  --database infoterminal \
+  --output /backups/infoterminal-postgres-v0_2.sql.gz \
+  --verify
+```
+- Stores schema + data with checksum verification.
+- Set `DRY_RUN=1` to preview commands without executing.
+
+### 1.2 Neo4j (graph store)
+```bash
+./scripts/backup/neo4j.sh \
+  --edition enterprise \
+  --output /backups/neo4j-v0_2.dump \
+  --quiesce-cluster
+```
+- Requires enterprise backup privileges.
+- Confirm `dbms.backup.enabled=true` in `neo4j.conf`.
+
+### 1.3 OpenSearch (document index)
+```bash
+./scripts/backup/opensearch_snapshot.sh \
+  --repo infoterminal-upgrade \
+  --snapshot pre-v1_0 \
+  --region local
+```
+- Ensure repository path has read/write access for the OpenSearch nodes.
+
+### 1.4 MinIO Object Storage
+```bash
+mc mirror --overwrite minio/infoterminal /backups/minio-pre-v1_0
+```
+
+> ✅ **Verification:** List all artifacts in `/backups` and confirm timestamps before continuing.
+
+---
+
+## 2. Enable v1.0 Feature Flags
+Version 1.0 introduces capability toggles to stage new functionality safely.
+
+| Flag | Target Service | Default | Action |
+| --- | --- | --- | --- |
+| `DOC_ENTITY_V1` | `doc-entities` | `false` | Set to `true` once migrations succeed. |
+| `GRAPH_ALGO_V1` | `graph-api` | `false` | Enable to expose Louvain/community APIs. |
+| `GATEWAY_OIDC_ENFORCE` | `gateway` | `false` | Turn on after validating IdP connectivity. |
+| `OBS_ENRICH_TRACES` | `observability` | `false` | Enable after Tempo schema upgrade. |
+
+Apply flags using the bundled helper script:
+```bash
+./deploy/set_flag.sh --flag DOC_ENTITY_V1 --value true --release v1.0
+```
+The script writes to Consul/etcd (depending on your configuration) and restarts services if `--apply` is passed. Always begin with `--dry-run` to preview changes.
+
+---
+
+## 3. Run Database & Index Migrations
+Execute the migrations in the listed order to maintain referential integrity.
+
+1. **PostgreSQL**
+   ```bash
+   make db-migrate scope=postgres target=v1_0
+   ```
+   - Adds dossier templates table.
+   - Normalizes audit log timestamps to UTC.
+2. **Neo4j**
+   ```bash
+   make db-migrate scope=neo4j target=v1_0
+   ```
+   - Introduces `COMMUNITY` relationship labels.
+   - Recomputes node centrality scores.
+3. **OpenSearch**
+   ```bash
+   make db-migrate scope=opensearch target=v1_0
+   ```
+   - Recreates document embeddings index with cosine similarity.
+
+> ⚠️ **Important:** Each migration step is idempotent. Re-running will skip completed changes based on migration logs stored in the respective databases.
+
+After migrations finish, re-run `make upgrade-precheck` to confirm no pending operations remain.
+
+---
+
+## 4. Upgrade Application Services
+1. Update configuration overlays:
+   ```bash
+   cp deploy/overlays/v1.0/*.yaml deploy/current/
+   git diff deploy/current
+   ```
+2. Apply container updates:
+   ```bash
+   docker compose -f docker-compose.prod.yml pull
+   docker compose -f docker-compose.prod.yml up -d --build
+   ```
+3. Monitor startup logs for each service:
+   ```bash
+   docker compose logs -f gateway search-api graph-api doc-entities
+   ```
+4. For Kubernetes deployments, use the Helm chart:
+   ```bash
+   helm upgrade infoterminal charts/infoterminal \
+     --values deploy/overlays/v1.0/values.yaml \
+     --install --wait
+   ```
+
+---
+
+## 5. Post-Upgrade Validation
+1. **Health checks**
+   ```bash
+   ./scripts/healthcheck.sh --targets gateway,graph-api,search-api,doc-entities
+   ```
+2. **Data verification**
+   - Confirm new dossier templates appear in the UI.
+   - Run `GET /graph/communities` and expect HTTP 200 with `louvain` metadata.
+   - Execute `POST /doc-entities/summarize` and confirm `model_version: "1.0"`.
+3. **Observability**
+   - Check Grafana dashboards for new panels `v1.0 - Graph Algorithms`.
+   - Ensure Loki ingests structured JSON logs with `trace_id` field.
+4. **Smoke tests**
+   ```bash
+   make smoke
+   ```
+
+Document all results in your change management ticket.
+
+---
+
+## 6. Rollback & Recovery Plan
+- **If migrations fail**: Restore from backups in reverse order (OpenSearch → Neo4j → PostgreSQL) using the corresponding restore scripts with the `--restore` flag.
+- **If services fail post-upgrade**: Re-deploy the v0.2 compose bundle or Helm release and toggle feature flags back to `false`.
+- **Audit**: Capture logs from failing pods/containers and attach them to the incident report.
+
+---
+
+## Appendix A. Demo Script
+Run the synthetic upgrade to verify tooling and operator familiarity:
+```bash
+bash artifacts/upgrade/v02_to_v10_demo.sh \
+  --workspace /tmp/infoterminal-upgrade-demo \
+  --dry-run
+```
+The script provisions a mock v0.2 dataset, executes mock migrations, and produces a v1.0 artifact folder. Inspect the generated report at `artifacts/upgrade/report.md` for a summary of operations.
+


### PR DESCRIPTION
## Summary
- document the step-by-step v0.2 to v1.0 upgrade workflow including backups, migrations, and validation gates
- add a synthetic rehearsal script plus generated report to demonstrate the upgrade process end-to-end

## Testing
- bash artifacts/upgrade/v02_to_v10_demo.sh --keep-workspace

------
https://chatgpt.com/codex/tasks/task_e_68da593da4c88324b62942f0e06ef18d