### PR TITLE
chore(ci): enforce OpenAPI compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,22 @@ jobs:
         run: |
           pytest -q
 
+  api_compat:
+    name: API Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: scripts/requirements-api.txt
+      - name: Install OpenAPI tooling
+        run: pip install -r scripts/requirements-api.txt
+      - name: Check frozen OpenAPI schema
+        run: python scripts/check_api_compat.py
+
   frontend:
     name: Frontend (apps/frontend)
     runs-on: ubuntu-latest

--- a/artifacts/api/openapi-v1.0.json
+++ b/artifacts/api/openapi-v1.0.json
@@ -1,0 +1,1069 @@
+{
+  "components": {
+    "schemas": {
+      "DocumentResponse": {
+        "description": "Single document response.",
+        "properties": {
+          "found": {
+            "description": "Whether document was found",
+            "title": "Found",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Document ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document source data",
+            "title": "Source"
+          }
+        },
+        "required": [
+          "id",
+          "found"
+        ],
+        "title": "DocumentResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "IndexRequest": {
+        "description": "Document indexing request.",
+        "properties": {
+          "documents": {
+            "description": "List of documents to index",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Documents",
+            "type": "array"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Target index name (optional)",
+            "title": "Index"
+          }
+        },
+        "required": [
+          "documents"
+        ],
+        "title": "IndexRequest",
+        "type": "object"
+      },
+      "IndexResponse": {
+        "description": "Document indexing response.",
+        "properties": {
+          "errors": {
+            "description": "Indexing errors",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Errors",
+            "type": "array"
+          },
+          "indexed": {
+            "description": "Number of documents indexed",
+            "title": "Indexed",
+            "type": "integer"
+          },
+          "took_ms": {
+            "description": "Indexing time in milliseconds",
+            "title": "Took Ms",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "indexed",
+          "took_ms"
+        ],
+        "title": "IndexResponse",
+        "type": "object"
+      },
+      "PaginatedResponse_SearchResult_": {
+        "properties": {
+          "has_next": {
+            "description": "Whether there are more pages",
+            "title": "Has Next",
+            "type": "boolean"
+          },
+          "has_prev": {
+            "description": "Whether there are previous pages",
+            "title": "Has Prev",
+            "type": "boolean"
+          },
+          "items": {
+            "description": "List of items for current page",
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "description": "Current page number",
+            "title": "Page",
+            "type": "integer"
+          },
+          "pages": {
+            "description": "Total number of pages",
+            "title": "Pages",
+            "type": "integer"
+          },
+          "size": {
+            "description": "Items per page",
+            "title": "Size",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total number of items",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "size",
+          "pages",
+          "has_next",
+          "has_prev"
+        ],
+        "title": "PaginatedResponse[SearchResult]",
+        "type": "object"
+      },
+      "SearchRequest": {
+        "description": "Search request model.",
+        "properties": {
+          "facets": {
+            "description": "Fields to return facet counts for",
+            "items": {
+              "type": "string"
+            },
+            "title": "Facets",
+            "type": "array"
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Search filters by field",
+            "title": "Filters"
+          },
+          "highlight": {
+            "default": true,
+            "description": "Whether to include search result highlighting",
+            "title": "Highlight",
+            "type": "boolean"
+          },
+          "q": {
+            "description": "Search query string",
+            "title": "Q",
+            "type": "string"
+          },
+          "sort": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Sort configuration with field and order",
+            "title": "Sort"
+          }
+        },
+        "required": [
+          "q"
+        ],
+        "title": "SearchRequest",
+        "type": "object"
+      },
+      "SearchResult": {
+        "description": "Individual search result.",
+        "properties": {
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document body content",
+            "title": "Body"
+          },
+          "entities": {
+            "description": "Extracted entities",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Entities",
+            "type": "array"
+          },
+          "id": {
+            "description": "Document ID",
+            "title": "Id",
+            "type": "string"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Additional metadata",
+            "title": "Meta"
+          },
+          "score": {
+            "description": "Relevance score",
+            "title": "Score",
+            "type": "number"
+          },
+          "snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Search result snippet",
+            "title": "Snippet"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Document title",
+            "title": "Title"
+          }
+        },
+        "required": [
+          "id",
+          "score"
+        ],
+        "title": "SearchResult",
+        "type": "object"
+      },
+      "StandardError": {
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "description": "Error code for programmatic handling",
+                "type": "string"
+              },
+              "details": {
+                "description": "Additional error context",
+                "type": "object"
+              },
+              "message": {
+                "description": "Human-readable error message",
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "ValidationError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/StandardError"
+          },
+          {
+            "properties": {
+              "validation_errors": {
+                "description": "List of field validation errors",
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "description": "API key authentication",
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
+      },
+      "BearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "JWT Bearer token authentication",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "support@infoterminal.org",
+      "name": "InfoTerminal API Support",
+      "url": "https://github.com/161sam/InfoTerminal"
+    },
+    "description": "Search and indexing service for InfoTerminal OSINT platform",
+    "license": {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "title": "InfoTerminal Search API",
+    "version": "1.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Service information and available endpoints.",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Root",
+        "tags": [
+          "root"
+        ]
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Health check endpoint (legacy response schema).",
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthz",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/query": {
+      "post": {
+        "deprecated": true,
+        "description": "DEPRECATED: Use /v1/search instead.\n\nLegacy query endpoint for backward compatibility.\nWill be removed in a future version.",
+        "operationId": "legacy_query_query_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Legacy Query",
+        "tags": [
+          "legacy"
+        ]
+      }
+    },
+    "/readyz": {
+      "get": {
+        "description": "Readiness check endpoint with legacy response schema.",
+        "operationId": "readyz_readyz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Readyz",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/search": {
+      "get": {
+        "deprecated": true,
+        "description": "DEPRECATED: Use /v1/search instead.\n\nLegacy search endpoint for backward compatibility.\nWill be removed in a future version.",
+        "operationId": "legacy_search_search_get",
+        "parameters": [
+          {
+            "description": "Search query string",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "description": "Search query string",
+              "title": "Q",
+              "type": "string"
+            }
+          },
+          {
+            "description": "comma-separated entity types",
+            "in": "query",
+            "name": "entity_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "comma-separated entity types",
+              "title": "Entity Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rerank",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rerank"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Rerank",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Rerank"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Legacy Search",
+        "tags": [
+          "legacy"
+        ]
+      },
+      "post": {
+        "deprecated": true,
+        "description": "DEPRECATED: Use /v1/search instead.\n\nLegacy search endpoint for backward compatibility.\nWill be removed in a future version.",
+        "operationId": "legacy_search_search_post",
+        "parameters": [
+          {
+            "description": "Search query string",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "description": "Search query string",
+              "title": "Q",
+              "type": "string"
+            }
+          },
+          {
+            "description": "comma-separated entity types",
+            "in": "query",
+            "name": "entity_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "comma-separated entity types",
+              "title": "Entity Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rerank",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Rerank"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Rerank",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Rerank"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Legacy Search",
+        "tags": [
+          "legacy"
+        ]
+      }
+    },
+    "/v1/documents/{doc_id}": {
+      "delete": {
+        "description": "Delete a specific document by ID",
+        "operationId": "delete_document_v1_documents__doc_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "doc_id",
+            "required": true,
+            "schema": {
+              "title": "Doc Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete document by ID",
+        "tags": [
+          "v1",
+          "search"
+        ]
+      },
+      "get": {
+        "description": "Retrieve a specific document by ID",
+        "operationId": "get_document_v1_documents__doc_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "doc_id",
+            "required": true,
+            "schema": {
+              "title": "Doc Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get document by ID",
+        "tags": [
+          "v1",
+          "search"
+        ]
+      }
+    },
+    "/v1/index/documents": {
+      "post": {
+        "description": "Index documents for search",
+        "operationId": "index_documents_v1_index_documents_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Index documents",
+        "tags": [
+          "v1",
+          "indexing"
+        ]
+      }
+    },
+    "/v1/search": {
+      "post": {
+        "description": "Search across indexed documents with filters, sorting, and pagination",
+        "operationId": "search_documents_v1_search_post",
+        "parameters": [
+          {
+            "description": "Enable AI-powered result reranking",
+            "in": "query",
+            "name": "enable_rerank",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Enable AI-powered result reranking",
+              "title": "Enable Rerank",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Size",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_SearchResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Search documents",
+        "tags": [
+          "v1",
+          "search"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Development server (local process)",
+      "url": "http://localhost:8401"
+    },
+    {
+      "description": "Development server (Docker container)",
+      "url": "http://localhost:8611"
+    }
+  ],
+  "tags": [
+    {
+      "description": "Search operations across indexed documents",
+      "name": "search"
+    },
+    {
+      "description": "Document indexing and management",
+      "name": "indexing"
+    },
+    {
+      "description": "Health and readiness checks",
+      "name": "health"
+    }
+  ]
+}

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,20 @@
+# API Versioning & Compatibility
+
+InfoTerminal APIs follow **Semantic Versioning**. The `v1` namespace of the Search API is frozen at version `1.0.0`; all changes are validated against the committed OpenAPI artefact at `artifacts/api/openapi-v1.0.json`.
+
+## Versioning Policy
+
+- **MAJOR (1.x → 2.0)** – Breaking changes that remove endpoints, change request/response schemas, or relax required authentication. Requires a new `/v{N}` namespace and migration guide.
+- **MINOR (1.0 → 1.1)** – Backwards-compatible feature work. You may add optional fields, new endpoints, or new response codes that do not break existing consumers.
+- **PATCH (1.0.0 → 1.0.1)** – Backwards-compatible fixes such as documentation updates, bug fixes, or performance improvements that do not alter request/response contracts.
+
+Changes to shared schemas, parameters, or responses that invalidate existing clients are considered **breaking** and must ship behind a new major version.
+
+## Compatibility Gate
+
+CI runs `scripts/check_api_compat.py` via the `api_compat` job. The gate regenerates the Search API specification and compares it with the frozen artefact. The job fails when:
+
+- An existing path, method, parameter, or response is removed or modified.
+- A schema under `components/schemas` changes in an incompatible way.
+
+If you intentionally introduce a breaking change, bump the major version, generate a new artefact (e.g. `openapi-v2.0.json`), and document the migration path.

--- a/scripts/check_api_compat.py
+++ b/scripts/check_api_compat.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Check OpenAPI compatibility against the frozen artefact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from generate_openapi_artifact import generate_openapi
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_PATH = REPO_ROOT / "artifacts" / "api" / "openapi-v1.0.json"
+
+
+class CompatibilityError(Exception):
+    """Raised when a breaking change is detected."""
+
+
+def load_schema(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise CompatibilityError(f"baseline OpenAPI artefact missing: {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:  # pragma: no cover - sanity
+        raise CompatibilityError(f"failed to parse OpenAPI artefact {path}: {exc}") from exc
+
+
+def _index_parameters(params: Iterable[Dict[str, Any]]) -> Dict[tuple[str, str], Dict[str, Any]]:
+    indexed: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for param in params:
+        key = (param.get("name"), param.get("in"))
+        indexed[key] = param
+    return indexed
+
+
+def _normalise_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a subset of schema fields relevant for compatibility checks."""
+
+    if not isinstance(schema, dict):
+        return schema
+
+    normalised = dict(schema)
+    for key in ["description", "title", "example", "examples", "deprecated"]:
+        normalised.pop(key, None)
+
+    if "properties" in normalised:
+        normalised["properties"] = {
+            name: _normalise_schema(value)
+            for name, value in normalised["properties"].items()
+        }
+    if "items" in normalised and isinstance(normalised["items"], dict):
+        normalised["items"] = _normalise_schema(normalised["items"])
+
+    return normalised
+
+
+def _compare_parameters(old_params: Iterable[Dict[str, Any]], new_params: Iterable[Dict[str, Any]], path: str, method: str, problems: list[str]) -> None:
+    old_index = _index_parameters(old_params)
+    new_index = _index_parameters(new_params)
+
+    for key, old_param in old_index.items():
+        if key not in new_index:
+            problems.append(f"{path} {method}: parameter {key} removed")
+            continue
+
+        new_param = new_index[key]
+        for field in ["required", "schema", "content"]:
+            if field not in old_param:
+                continue
+            if field not in new_param:
+                problems.append(f"{path} {method}: parameter {key} missing field '{field}'")
+                continue
+            if field == "schema":
+                if _normalise_schema(old_param[field]) != _normalise_schema(new_param[field]):
+                    problems.append(f"{path} {method}: parameter {key} schema changed")
+            else:
+                if old_param[field] != new_param[field]:
+                    problems.append(f"{path} {method}: parameter {key} field '{field}' changed")
+
+
+def _compare_request_body(old_body: Dict[str, Any], new_body: Dict[str, Any], path: str, method: str, problems: list[str]) -> None:
+    if not old_body:
+        return
+    if not new_body:
+        problems.append(f"{path} {method}: request body removed")
+        return
+
+    if old_body.get("required") and not new_body.get("required"):
+        problems.append(f"{path} {method}: request body no longer required")
+
+    old_content = old_body.get("content", {})
+    new_content = new_body.get("content", {})
+    for media_type, old_media in old_content.items():
+        if media_type not in new_content:
+            problems.append(f"{path} {method}: request body media type {media_type} removed")
+            continue
+        old_schema = _normalise_schema(old_media.get("schema", {}))
+        new_schema = _normalise_schema(new_content[media_type].get("schema", {}))
+        if old_schema != new_schema:
+            problems.append(f"{path} {method}: request body schema for {media_type} changed")
+
+
+def _compare_responses(old_responses: Dict[str, Any], new_responses: Dict[str, Any], path: str, method: str, problems: list[str]) -> None:
+    for status_code, old_response in old_responses.items():
+        if status_code not in new_responses:
+            problems.append(f"{path} {method}: response {status_code} removed")
+            continue
+        new_response = new_responses[status_code]
+        old_content = old_response.get("content", {})
+        new_content = new_response.get("content", {})
+        for media_type, old_media in old_content.items():
+            if media_type not in new_content:
+                problems.append(f"{path} {method}: response {status_code} media {media_type} removed")
+                continue
+            old_schema = _normalise_schema(old_media.get("schema", {}))
+            new_schema = _normalise_schema(new_content[media_type].get("schema", {}))
+            if old_schema != new_schema:
+                problems.append(f"{path} {method}: response {status_code} schema for {media_type} changed")
+
+
+def _compare_components(old_components: Dict[str, Any], new_components: Dict[str, Any], problems: list[str]) -> None:
+    old_schemas = old_components.get("schemas", {})
+    new_schemas = new_components.get("schemas", {})
+    for name, old_schema in old_schemas.items():
+        if name not in new_schemas:
+            problems.append(f"component schema {name} removed")
+            continue
+        if _normalise_schema(old_schema) != _normalise_schema(new_schemas[name]):
+            problems.append(f"component schema {name} changed")
+
+
+def check_backward_compatible(old_schema: Dict[str, Any], new_schema: Dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+
+    old_paths = old_schema.get("paths", {})
+    new_paths = new_schema.get("paths", {})
+    for path, old_methods in old_paths.items():
+        if path not in new_paths:
+            problems.append(f"path {path} removed")
+            continue
+        new_methods = new_paths[path]
+        for method, old_operation in old_methods.items():
+            if method.startswith("x-"):
+                continue
+            new_operation = new_methods.get(method)
+            if new_operation is None:
+                problems.append(f"{path}: method {method} removed")
+                continue
+            _compare_parameters(
+                old_operation.get("parameters", []),
+                new_operation.get("parameters", []),
+                path,
+                method,
+                problems,
+            )
+            _compare_request_body(
+                old_operation.get("requestBody"),
+                new_operation.get("requestBody"),
+                path,
+                method,
+                problems,
+            )
+            _compare_responses(
+                old_operation.get("responses", {}),
+                new_operation.get("responses", {}),
+                path,
+                method,
+                problems,
+            )
+
+    _compare_components(
+        old_schema.get("components", {}),
+        new_schema.get("components", {}),
+        problems,
+    )
+
+    return problems
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check API compatibility")
+    parser.add_argument(
+        "--service",
+        default="search-api",
+        help="Service name (folder under services/)"
+    )
+    parser.add_argument(
+        "--module",
+        default="search_api.app.main_v1",
+        help="Python module containing the FastAPI app"
+    )
+    parser.add_argument(
+        "--artefact",
+        type=Path,
+        default=ARTIFACT_PATH,
+        help="Path to the frozen OpenAPI artefact"
+    )
+
+    args = parser.parse_args()
+
+    baseline = load_schema(args.artefact)
+    current = generate_openapi(args.service, args.module)
+
+    problems = check_backward_compatible(baseline, current)
+    if problems:
+        details = "\n - ".join([""] + problems)
+        raise SystemExit(f"Breaking API changes detected:{details}")
+
+    print("API compatibility check passed: no breaking changes detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_openapi_artifact.py
+++ b/scripts/generate_openapi_artifact.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate frozen OpenAPI artefacts for InfoTerminal services."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVICES_DIR = REPO_ROOT / "services"
+
+
+def _load_fastapi_app(service: str, module_path: str) -> "FastAPI":
+    """Import the FastAPI application for the given service."""
+
+    service_src = SERVICES_DIR / f"{service}" / "src"
+    if not service_src.exists():
+        raise SystemExit(f"service '{service}' does not contain a src/ directory")
+
+    # Ensure both the shared service helpers and the service package itself are importable.
+    sys.path.insert(0, str(SERVICES_DIR))
+    sys.path.insert(0, str(service_src))
+
+    module: ModuleType = importlib.import_module(module_path)
+    app = getattr(module, "app", None)
+    if app is None:
+        raise SystemExit(f"module '{module_path}' does not expose a FastAPI 'app'")
+    return app
+
+
+def generate_openapi(service: str, module_path: str) -> dict[str, Any]:
+    """Return the OpenAPI schema for the specified FastAPI app."""
+
+    app = _load_fastapi_app(service, module_path)
+    schema = app.openapi()
+    if not isinstance(schema, dict):
+        raise SystemExit("FastAPI returned a non-dict OpenAPI schema")
+    return schema
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate OpenAPI artefact")
+    parser.add_argument(
+        "--service",
+        default="search-api",
+        help="Service name (folder under services/)"
+    )
+    parser.add_argument(
+        "--module",
+        default="search_api.app.main_v1",
+        help="Python module containing the FastAPI app"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "artifacts" / "api" / "openapi-v1.0.json",
+        help="Path to write the OpenAPI JSON artefact"
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Indentation for the JSON output"
+    )
+
+    args = parser.parse_args()
+    schema = generate_openapi(args.service, args.module)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(schema, indent=args.indent, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/requirements-api.txt
+++ b/scripts/requirements-api.txt
@@ -1,0 +1,7 @@
+fastapi>=0.111,<0.112
+pydantic>=2.7,<3
+httpx>=0.27,<0.28
+cachetools>=5.3,<6
+prometheus-client>=0.20,<0.21
+python-jose[cryptography]>=3.3,<3.4
+numpy>=1.26,<2


### PR DESCRIPTION
## Summary
- freeze the Search API v1 OpenAPI schema under `artifacts/api/openapi-v1.0.json`
- add generation/check scripts plus lightweight requirements to automate the artefact
- wire an `api_compat` CI job and document the SemVer policy in `docs/api/versioning.md`

## Testing
- python scripts/check_api_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68da6e7f212c8324ac564fd14e26b047