### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled command line

### DIFF
--- a/services/ops-controller/routers/ops_controller_v1.py
+++ b/services/ops-controller/routers/ops_controller_v1.py
@@ -397,9 +397,15 @@ def get_stack_logs(
         N = str(tail or TAIL)
         _audit("stack_logs", request, stack=name, service=service)
 
+        # Validate the `service` parameter if provided
+        valid_services = list(stacks[name].get("services", {}).keys())
+
         def stream():
             args = ["logs", "-f", "--tail", N]
             if service:
+                if service not in valid_services:
+                    yield f"Error: Invalid service name '{service}'\n".encode()
+                    return
                 args.append(service)
             
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/161sam/InfoTerminal/security/code-scanning/35](https://github.com/161sam/InfoTerminal/security/code-scanning/35)

To fix this issue, the parameter `service` (user-controlled) must never be passed directly to subprocess commands unless it is verified to be a valid service name for the selected stack. The best fix is to cross-reference the provided `service` parameter with the list of services defined in the stack’s Docker Compose files (for the given `name`). Only if the parameter matches a known, valid service name should it be appended to the command-line arguments. Otherwise, the function should raise an error.

Changes to make:
- Before using `service` in the command (lines 402–403), check whether `service` is either `None` or is present in the list of services for the selected stack.
- Retrieve the valid list of services for the stack.
- If the supplied `service` is not valid, raise a well-defined HTTP error.
- No changes needed to function signature, imports, etc., unless a new helper to get the service list is required. We can inline this logic using the stack's compose file specification, if readily available, or else validate only against the dict obtained from `_stacks()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
