### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled command line

### DIFF
--- a/services/ops-controller/app.py
+++ b/services/ops-controller/app.py
@@ -197,6 +197,11 @@ def stack_logs(name: str, service: Optional[str]=None, tail: Optional[int]=None,
     stacks = _stacks()["stacks"]
     if name not in stacks: raise HTTPException(404,"unknown stack")
     files = stacks[name]["files"]
+    # Validate that service is in the set of known services for the stack (if provided)
+    valid_services = stacks[name].get("services", [])
+    if service:
+        if not isinstance(service, str) or service.strip() == "" or service not in valid_services:
+            raise HTTPException(400, f"Service '{service}' not found in stack '{name}'")
     N = str(tail or TAIL)
     _audit("stack_logs", request, stack=name, service=service)
 


### PR DESCRIPTION
Potential fix for [https://github.com/161sam/InfoTerminal/security/code-scanning/21](https://github.com/161sam/InfoTerminal/security/code-scanning/21)

To fix this issue, we must validate that the user-supplied `service` argument matches one of the valid service names defined in the specified stack's configuration. That means:
1. Retrieve the list of valid services in the target stack (from the stack definition loaded via YAML).
2. If `service` is provided, check that it strictly matches one of the expected valid service names.
3. Reject all other values, raising an HTTP 400 or 404 error.

This change must happen in the `stack_logs` endpoint handler (lines 195–213), before `service` is appended to the command.  
No new methods or dependencies are required; simple Python code suffices for the validation.  
You may need to extract the list of valid services for a given stack. If that's not readily available from `stacks[name]`, you can parse it from the stack files (possibly YAML), but for now, assume there's a way to get a list of defined service names in `stacks[name]`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
